### PR TITLE
[CLEANUP] - upgrading to maven-assembly-plugin 3.0.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,14 +54,13 @@
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-site-plugin.version>3.4</maven-site-plugin.version>
     <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
-    <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
     <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
     <requirejs-maven-plugin.version>2.0.4</requirejs-maven-plugin.version>
     <frontend-maven-plugin.version>1.3</frontend-maven-plugin.version>
     <directory-maven-plugin.version>0.1</directory-maven-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <iterator-maven-plugin.version>0.4</iterator-maven-plugin.version>
-    <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
+    <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
     <maven-failsafe-plugin.version>2.19</maven-failsafe-plugin.version>
@@ -69,13 +68,12 @@
     <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
     <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
     <maven-project-info-reports-plugin.version>2.8.1</maven-project-info-reports-plugin.version>
-    <maven-resources-plugin.version>2.7</maven-resources-plugin.version>
+    <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
     <maven-site-plugin.version>3.4</maven-site-plugin.version>
     <maven-source-plugin.version>2.4</maven-source-plugin.version>
     <maven-surefire-plugin.version>2.19</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>2.19</maven-surefire-report-plugin.version>
     <maven-verifier-plugin.version>1.1</maven-verifier-plugin.version>
-    <maven-bundle-plugin.version>2.5.3</maven-bundle-plugin.version>
     <sonar-maven-plugin.version>2.7.1</sonar-maven-plugin.version>
     <!-- DO NOT, under ANY circumstance, use maven-bundle-plugin verion 2.5.4, it overrides all phase bindings with the default,
        and generally just makes a mess of things -->


### PR DESCRIPTION
This fixes a few issues that we have run into recently
* an issue with open filehandles on some laptops ( @tmcsantos )
* an issue generating zip files that are not compatible with the pentaho platform importer ( i found this while converting pentaho-platform-ee to maven)