### PR TITLE
[BACKLOG-15402] - adds new execution to install install-node-and-npm …

### DIFF
--- a/pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pentaho-ce-bundle-parent-pom/pom.xml
+++ b/pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pentaho-ce-bundle-parent-pom/pom.xml
@@ -78,6 +78,20 @@
         <plugins>
 
           <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>node-npm_install</id>
+                <phase>${node-npm_install-phase}</phase>
+                <goals>
+                  <goal>install-node-and-npm</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
             <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -616,6 +616,20 @@
 
       <build>
         <plugins>
+
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>node-npm_install</id>
+                <phase>${node-npm_install-phase}</phase>
+                <goals>
+                  <goal>install-node-and-npm</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
           
           <plugin>
             <groupId>com.github.bringking</groupId>


### PR DESCRIPTION
…in javascript bundle profiles.

This added executions are needed if we want to be able to build a single module from a multi-module project.

@pentaho/2-1b @smaring 