### PR TITLE
[BACKLOG-14318] Extra configuration for jsdoc to check if we are doing a local build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <bundle-javascript_unpack-rjs-phase>initialize</bundle-javascript_unpack-rjs-phase>
     <test-integration_add-source-phase>pre-integration-test</test-integration_add-source-phase>
     <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
-    <docjs.config.file></docjs.config.file>
+    <docjs.config.file/>
     <test-integration_jacoco-agent-prep-phase>pre-integration-test</test-integration_jacoco-agent-prep-phase>
     <test-unit-jacoco-report-phase>verify</test-unit-jacoco-report-phase>
     <build.dependenciesDirectory>${project.build.directory}/dependency</build.dependenciesDirectory>
@@ -597,6 +597,7 @@
         <karma.file.config>karma.ci.conf.js</karma.file.config>
       </properties>
     </profile>
+
     <profile>
       <id>javascript-doc</id>
       <activation>
@@ -607,6 +608,13 @@
           <exists>${basedir}/src/doc/javascript/config/${docjs.config.file}</exists>
         </file>
       </activation>
+
+      <properties>
+        <jsdoc3-maven-plugin.version>1.2.0</jsdoc3-maven-plugin.version>
+
+        <docjs.config.includePrivate>false</docjs.config.includePrivate>
+      </properties>
+
       <build>
         <pluginManagement>
           <plugins>
@@ -617,6 +625,7 @@
             </plugin>
           </plugins>
         </pluginManagement>
+
         <plugins>
           <plugin>
             <artifactId>maven-resources-plugin</artifactId>
@@ -642,9 +651,7 @@
           </plugin>
         </plugins>
       </build>
-      <properties>
-        <jsdoc3-maven-plugin.version>1.2.0</jsdoc3-maven-plugin.version>
-      </properties>
+
       <reporting>
         <plugins>
           <plugin>
@@ -652,6 +659,12 @@
             <artifactId>jsdoc3-maven-plugin</artifactId>
             <configuration>
               <configFile>${project.build.directory}/${docjs.config.file}</configFile>
+              <includePrivate>${docjs.config.includePrivate}</includePrivate>
+              <!--
+                 The jsdoc3 maven plugin requires the directoryRoots or sourceFiles defined
+                 as a work around we are defining the source file as the config file to enable
+                 the plugin and don't cause side effects on upstream projects configuration files
+              -->
               <sourceFiles>
                 <sourceFile>${project.build.directory}/${docjs.config.file}</sourceFile>
               </sourceFiles>


### PR DESCRIPTION
@pentaho/millenniumfalcon please review

I would prefer to have a property called "mindtouch" to control the switching but then we would need to negate the property value to disable private docs (mindtouch = true => jsdoc.config.opts.private = false), and this functionality isn't available in maven.