### PR TITLE
[BACKLOG-16958] Adds removal of node_modules dir to maven clean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -517,6 +517,34 @@
     </profile>
 
     <profile>
+      <id>clean-node-modules</id>
+      <activation>
+        <property>
+          <name>!skipNodeClean</name>
+        </property>
+        <file>
+          <exists>node_modules</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-clean-plugin</artifactId>
+            <version>${maven-clean-plugin.version}</version>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>node_modules</directory>
+                  <followSymlinks>false</followSymlinks>
+                </fileset>
+              </filesets>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>node-npm</id>
       <activation>
         <file>


### PR DESCRIPTION
@pentaho/x-wing @graimundo Please review

Can be bypassed by using a `skipNodeClean` property.