### PR TITLE
[BACKLOG-19308] - audit profile 

### DIFF
--- a/pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pom.xml
+++ b/pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pom.xml
@@ -33,10 +33,6 @@
     <!-- VERSIONS -->
     <junit.version>4.11</junit.version>
 
-    <coding-standards.version>8.1.0.0-SNAPSHOT</coding-standards.version>
-    <checkstyle.version>8.0</checkstyle.version>
-    <spotbugs.version>3.1.2</spotbugs.version>
-
     <!-- http://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html -->
     <maven-surefire-plugin.reuseForks>true</maven-surefire-plugin.reuseForks> <!-- default setting is reuseForks = true -->
     <maven-surefire-plugin.forkCount>1</maven-surefire-plugin.forkCount> <!-- default setting is forkCount = 1 -->
@@ -55,33 +51,13 @@
     <sonar.branch>${SCM_BRANCH}</sonar.branch>
     <sonar.jacoco.reportPath>${project.build.directory}/jacoco.exec</sonar.jacoco.reportPath>
     <sonar.jacoco.itReportPath>${project.build.directory}/jacoco-it.exec</sonar.jacoco.itReportPath>
+
+    <jacocoSurefireArgLine/> <!-- this is set by jacoco's prepare-agent execution -->
+    <jacocoFailsafeArgLine/> <!-- this is set by jacoco's prepare-agent execution -->
   </properties>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>test-unit-jacoco-agent-prep</id>
-            <phase>${test-unit-jacoco-agent-prep-phase}</phase>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-            <configuration>
-              <propertyName>jacocoSurefireArgLine</propertyName>
-            </configuration>
-          </execution>
-          <execution>
-            <id>test-unit-jacoco-report</id>
-            <phase>${test-unit-jacoco-report-phase}</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <executions>
@@ -92,7 +68,7 @@
               <goal>test</goal>
             </goals>
             <configuration>
-              <argLine>@{jacocoSurefireArgLine} ${maven-surefire-plugin.argLine}</argLine>
+              <argLine>-Dfile.encoding=${project.build.sourceEncoding} @{jacocoSurefireArgLine} ${maven-surefire-plugin.argLine}</argLine> <!-- this is set by jacoco's prepare-agent execution -->
               <forkCount>${maven-surefire-plugin.forkCount}</forkCount>
               <reuseForks>${maven-surefire-plugin.reuseForks}</reuseForks>
               <testFailureIgnore>${maven-surefire-plugin.testFailureIgnore}</testFailureIgnore>
@@ -111,22 +87,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>${checkstyle.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.pentaho</groupId>
-            <artifactId>coding-standards</artifactId>
-            <version>${coding-standards.version}</version>
-            <type>zip</type>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>
@@ -151,6 +111,9 @@
       <properties>
         <integration-test.resources>src/it/resources</integration-test.resources>
         <integration-test.src>src/it/java</integration-test.src>
+        <!-- only used in audit mode -->
+        <test-integration_jacoco-agent-prep-phase>pre-integration-test</test-integration_jacoco-agent-prep-phase>
+        <test-integration_jacoco-report-phase>verify</test-integration_jacoco-report-phase>
       </properties>
       <build>
         <plugins>
@@ -193,29 +156,6 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>test-integration_jacoco-agent-prep</id>
-                <phase>${test-integration_jacoco-agent-prep-phase}</phase>
-                <goals>
-                  <goal>prepare-agent-integration</goal>
-                </goals>
-                <configuration>
-                  <propertyName>jacocoFailsafeArgLine</propertyName>
-                </configuration>
-              </execution>
-              <execution>
-                <id>test-integration_jacoco-report</id>
-                <phase>${test-integration_jacoco-report-phase}</phase>
-                <goals>
-                  <goal>report-integration</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
             <executions>
               <execution>
@@ -252,7 +192,7 @@
               </execution>
             </executions>
             <configuration>
-              <argLine>@{jacocoFailsafeArgLine} ${maven-failsafe-plugin.argLine}</argLine>
+              <argLine>-Dfile.encoding=${project.build.sourceEncoding} @{jacocoFailsafeArgLine} ${maven-failsafe-plugin.argLine}</argLine> <!-- this is set by jacoco's prepare-agent-integration execution -->
               <forkCount>${maven-failsafe-plugin.forkCount}</forkCount>
               <reuseForks>${maven-failsafe-plugin.reuseForks}</reuseForks>
               <testClassesDirectory>${project.build.directory}/it-classes</testClassesDirectory>
@@ -261,97 +201,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-
-    <profile>
-      <id>reporting</id>
-      <activation>
-        <property>
-          <name>!maven.test.skip</name>
-        </property>
-      </activation>
-      <reporting>
-        <plugins>
-          <plugin>
-            <artifactId>maven-project-info-reports-plugin</artifactId>
-            <configuration>
-              <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-jxr-plugin</artifactId>
-            <reportSets>
-              <reportSet>
-                <id>jxr</id>
-                <reports>
-                  <report>jxr</report>
-                </reports>
-              </reportSet>
-            </reportSets>
-            <configuration>
-              <linkJavadoc>true</linkJavadoc>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <reportSets>
-              <reportSet>
-                <id>javadoc</id>
-                <reports>
-                  <report>javadoc</report>
-                </reports>
-              </reportSet>
-            </reportSets>
-            <configuration>
-              <failOnError>false</failOnError>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <reportSets>
-              <reportSet>
-                <id>checkstyle</id>
-                <reports>
-                  <report>checkstyle</report>
-                </reports>
-              </reportSet>
-            </reportSets>
-            <configuration>
-              <!--  configuration file comes from coding-standards artifact -->
-              <configLocation>checkstyle/pentaho_checks.xml</configLocation>
-              <linkXRef>true</linkXRef>
-              <cacheFile />
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-          </plugin>
-          <plugin>
-            <artifactId>maven-surefire-report-plugin</artifactId>
-            <reportSets>
-              <reportSet>
-                <id>unit-tests</id>
-                <reports>
-                  <report>report-only</report>
-                </reports>
-              </reportSet>
-              <reportSet>
-                <id>integration-tests</id>
-                <reports>
-                  <report>failsafe-report-only</report>
-                </reports>
-              </reportSet>
-            </reportSets>
-            <configuration>
-              <linkXRef>true</linkXRef>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-site-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </reporting>
     </profile>
 
     <profile>
@@ -377,63 +226,6 @@
                 </configuration>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>sonar</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>sonar-maven-plugin</artifactId>
-            <version>${sonar-maven-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>sonar_publish</id>
-                <configuration>
-                  <sonarHostURL>${sonar.host.url}</sonarHostURL>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    
-    <profile>
-      <id>spotbugs</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>${spotbugs.version}</version>
-            <configuration>
-              <includeFilterFile>findbugs/pentaho_checks.xml</includeFilterFile>
-            </configuration>
-            <executions>
-              <execution>
-                <id>spotbugs-check</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-            <dependencies>
-              <dependency>
-                <groupId>org.pentaho</groupId>
-                <artifactId>coding-standards</artifactId>
-                <version>${coding-standards.version}</version>
-                <type>zip</type>
-              </dependency>
-            </dependencies>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
   <properties>
     <!-- VERSIONS -->
-    <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.0</jacoco-maven-plugin.version>
     <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
@@ -74,18 +74,18 @@
     <frontend-maven-plugin.version>1.3</frontend-maven-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <iterator-maven-plugin.version>0.4</iterator-maven-plugin.version>
-    <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
+    <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
-    <maven-failsafe-plugin.version>2.19</maven-failsafe-plugin.version>
+    <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
     <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
     <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
     <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
     <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
     <maven-source-plugin.version>2.4</maven-source-plugin.version>
-    <maven-surefire-plugin.version>2.19</maven-surefire-plugin.version>
-    <maven-surefire-report-plugin.version>2.19</maven-surefire-report-plugin.version>
+    <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
+    <maven-surefire-report-plugin.version>2.21.0</maven-surefire-report-plugin.version>
     <maven-verifier-plugin.version>1.1</maven-verifier-plugin.version>
     <sonar-maven-plugin.version>2.7.1</sonar-maven-plugin.version>
     <license-helper-maven-plugin.version>1.26</license-helper-maven-plugin.version>
@@ -101,11 +101,13 @@
     <!-- jdk version -->
     <source.jdk.version>1.8</source.jdk.version>
     <target.jdk.version>1.8</target.jdk.version>
+    <checkstyle.version>8.0</checkstyle.version>
+    <coding-standards.version>8.1.0.0-SNAPSHOT</coding-standards.version>
+    <spotbugs.version>3.1.2</spotbugs.version>
 
     <!-- PHASE BINDINGS -->
     <set-highest-basedir-phase>initialize</set-highest-basedir-phase>
     <node-npm_install-phase>initialize</node-npm_install-phase>
-    <test-unit-jacoco-agent-prep-phase>initialize</test-unit-jacoco-agent-prep-phase>
     <eula-wrap_assign-deps-to-properties-phase>initialize</eula-wrap_assign-deps-to-properties-phase>
     <bundle-javascript_unpack-rjs-phase>initialize</bundle-javascript_unpack-rjs-phase>
     <javascript_unpack-dependencies-phase>initialize</javascript_unpack-dependencies-phase>
@@ -128,15 +130,12 @@
     <javascript-assembly_package-phase>package</javascript-assembly_package-phase>
     <test-integration_add-resources-phase>pre-integration-test</test-integration_add-resources-phase>
     <test-integration_add-source-phase>pre-integration-test</test-integration_add-source-phase>
-    <test-integration_jacoco-agent-prep-phase>pre-integration-test</test-integration_jacoco-agent-prep-phase>
     <test-integration_compile-phase>pre-integration-test</test-integration_compile-phase>
     <test-integration_execute-phase>integration-test</test-integration_execute-phase>
     <eula-wrap_create-izpack-installer-jar-phase>verify</eula-wrap_create-izpack-installer-jar-phase>
     <eula-wrap_create-dist-phase>verify</eula-wrap_create-dist-phase>
     <eula-wrap_attach-dist-phase>verify</eula-wrap_attach-dist-phase>
-    <test-unit-jacoco-report-phase>verify</test-unit-jacoco-report-phase>
     <attach-sources-phase>verify</attach-sources-phase>
-    <test-integration_jacoco-report-phase>verify</test-integration_jacoco-report-phase>
     <test-integration_report-phase>verify</test-integration_report-phase>
     <javascript-doc_copy-resources-phase>pre-site</javascript-doc_copy-resources-phase>
 
@@ -188,6 +187,12 @@
     <license.licenseFile>LICENSE.txt</license.licenseFile>
     <license.bundleLicenseFile>META-INF/LICENSE.txt</license.bundleLicenseFile>
     <license.failOnLicenseCheck>false</license.failOnLicenseCheck>
+
+    <!-- Chechstyle configuration -->
+    <!--  configuration file comes from coding-standards artifact -->
+    <checkstyle.configLocation>checkstyle/pentaho_checks.xml</checkstyle.configLocation>
+    <checkstyle.consoleOutput>true</checkstyle.consoleOutput>
+    <checkstyle.linkXRef>true</checkstyle.linkXRef>
     <pentaho-eula-wrap-config.version>8.1.0.0-SNAPSHOT</pentaho-eula-wrap-config.version>
 
     <!-- Documentation properties -->
@@ -293,10 +298,48 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
         </plugin>
+
         <plugin>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${maven-checkstyle-plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>${checkstyle.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.pentaho</groupId>
+              <artifactId>coding-standards</artifactId>
+              <version>${coding-standards.version}</version>
+              <type>zip</type>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <configLocation>${checkstyle.configLocation}</configLocation>
+            <linkXRef>${checkstyle.linkXRef}</linkXRef>
+            <consoleOutput>${checkstyle.consoleOutput}</consoleOutput>
+            <cacheFile/>
+          </configuration>
         </plugin>
+
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>${spotbugs.version}</version>
+          <configuration>
+            <includeFilterFile>findbugs/pentaho_checks.xml</includeFilterFile>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.pentaho</groupId>
+              <artifactId>coding-standards</artifactId>
+              <version>${coding-standards.version}</version>
+              <type>zip</type>
+            </dependency>
+          </dependencies>
+        </plugin>
+
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>sonar-maven-plugin</artifactId>
@@ -329,6 +372,7 @@
           <configuration>
             <source>${source.jdk.version}</source>
             <target>${target.jdk.version}</target>
+            <compilerArgument>${compilerArgument}</compilerArgument>
           </configuration>
         </plugin>
         <plugin>
@@ -412,6 +456,12 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-release-plugin</artifactId>
       </plugin>
       <plugin>
@@ -466,6 +516,7 @@
           </execution>
         </executions>
       </plugin>
+
     </plugins>
   </build>
 
@@ -1119,6 +1170,190 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>audit</id>
+      <activation>
+        <property>
+          <name>audit</name>
+        </property>
+      </activation>
+      <properties>
+        <checkstyle.consoleOutput>false</checkstyle.consoleOutput>
+        <checkstyle.linkXRef>false</checkstyle.linkXRef>
+        <test-unit-jacoco-agent-prep-phase>initialize</test-unit-jacoco-agent-prep-phase>
+        <test-unit-jacoco-report-phase>verify</test-unit-jacoco-report-phase>
+        <!-- disabled by default, will be enabled if runITs -->
+        <test-integration_jacoco-agent-prep-phase/>
+        <test-integration_jacoco-report-phase/>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>checkstyle</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>checkstyle</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>test-unit-jacoco-agent-prep</id>
+                <phase>${test-unit-jacoco-agent-prep-phase}</phase>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+                <configuration>
+                  <propertyName>jacocoSurefireArgLine</propertyName>
+                </configuration>
+              </execution>
+              <execution>
+                <id>test-unit-jacoco-report</id>
+                <phase>${test-unit-jacoco-report-phase}</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+              <!-- integration tests -->
+              <execution>
+                <id>test-integration_jacoco-agent-prep</id>
+                <phase>${test-integration_jacoco-agent-prep-phase}</phase>
+                <goals>
+                  <goal>prepare-agent-integration</goal>
+                </goals>
+                <configuration>
+                  <propertyName>jacocoFailsafeArgLine</propertyName>
+                </configuration>
+              </execution>
+              <execution>
+                <id>test-integration_jacoco-report</id>
+                <phase>${test-integration_jacoco-report-phase}</phase>
+                <goals>
+                  <goal>report-integration</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>spotbugs</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>spotbugs-check</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>reporting</id>
+      <activation>
+        <property>
+          <name>!maven.test.skip</name>
+        </property>
+      </activation>
+      <reporting>
+        <plugins>
+          <plugin>
+            <artifactId>maven-project-info-reports-plugin</artifactId>
+            <configuration>
+              <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-jxr-plugin</artifactId>
+            <reportSets>
+              <reportSet>
+                <id>jxr</id>
+                <reports>
+                  <report>jxr</report>
+                </reports>
+              </reportSet>
+            </reportSets>
+            <configuration>
+              <linkJavadoc>true</linkJavadoc>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <reportSets>
+              <reportSet>
+                <id>javadoc</id>
+                <reports>
+                  <report>javadoc</report>
+                </reports>
+              </reportSet>
+            </reportSets>
+            <configuration>
+              <failOnError>false</failOnError>
+            </configuration>
+          </plugin>
+            <plugin>
+              <artifactId>maven-checkstyle-plugin</artifactId>
+              <reportSets>
+                <reportSet>
+                  <id>checkstyle</id>
+                  <reports>
+                    <report>checkstyle</report>
+                  </reports>
+                </reportSet>
+              </reportSets>
+              <configuration>
+                <consoleOutput>false</consoleOutput>
+                <linkXRef>true</linkXRef>
+              </configuration>
+            </plugin>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <artifactId>maven-surefire-report-plugin</artifactId>
+            <reportSets>
+              <reportSet>
+                <id>unit-tests</id>
+                <reports>
+                  <report>report-only</report>
+                </reports>
+              </reportSet>
+              <reportSet>
+                <id>integration-tests</id>
+                <reports>
+                  <report>failsafe-report-only</report>
+                </reports>
+              </reportSet>
+            </reportSets>
+            <configuration>
+              <linkXRef>true</linkXRef>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-site-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </reporting>
     </profile>
    <!-- Support Nexus Staging Deployment -->
    <profile>


### PR DESCRIPTION
- Adds code-audit profile.
- Moves checkestyle to code-audit and bind it to validate phase.
- Moves jacoco reports to code-audit.

depends on:
https://github.com/pentaho/pentaho-wingman/pull/90