### PR TITLE
[PPP-4108] Use of vulnerable component jackson-databind-2.8.8.jar, ja…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,9 @@
     <npm.version>5.7.1</npm.version>
     <rjs.version>2.3.5</rjs.version>
 
+    <codehaus-jackson.version>1.9.13</codehaus-jackson.version>
+    <fasterxml-jackson.version>2.9.5</fasterxml-jackson.version>
+
     <!-- jdk version -->
     <source.jdk.version>1.8</source.jdk.version>
     <target.jdk.version>1.8</target.jdk.version>
@@ -201,6 +204,83 @@
     <doc.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</doc.version>
     <doc.base.url>https://help.pentaho.com/Documentation/${doc.version}</doc.base.url>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-jaxrs</artifactId>
+        <version>${codehaus-jackson.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-mapper-asl</artifactId>
+        <version>${codehaus-jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-core-asl</artifactId>
+        <version>${codehaus-jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-xc</artifactId>
+        <version>${codehaus-jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${fasterxml-jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${fasterxml-jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${fasterxml-jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>${fasterxml-jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-base</artifactId>
+        <version>${fasterxml-jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-jaxb-annotations</artifactId>
+        <version>${fasterxml-jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${fasterxml-jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-smile</artifactId>
+        <version>${fasterxml-jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-cbor</artifactId>
+        <version>${fasterxml-jackson.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <distributionManagement>
     <repository>


### PR DESCRIPTION
…ckson-databind-2.9.2.jar, jackson-mapper-asl-1.9.2.jar CVE-2017-7525, CVE-2017-15095, CVE-2017-15095

This is the first in a series of pull requests to upgrade `org.codehaus.jackson` and `com.fasterxml.jackson` to the latest available version. To note:

* Dependency management is now in the parent POM (this project)
* Removed several unused dependencies of `com.fasterxml.jackson`
* Removed some unused dependencies of `org.codehaus.jackson`
* All projects will now use `com.fasterxml.jackson` - **2.9.5**
* All projects will now use `org.codehaus.jackson` - **1.9.13**
* Most dependencies of `org.codehaus.jackson` have been upgraded to `com.fasterxml.jackson`
* Some dependencies can't be upgraded due to transitive dependencies

This is the full list of PRs:

* https://github.com/pentaho/maven-parent-poms/pull/66 (this one)
* https://github.com/pentaho/pentaho-osgi-bundles/pull/275
* https://github.com/webdetails/cpf/pull/123
* https://github.com/pentaho/pentaho-kettle/pull/5485
* https://github.com/pentaho/pentaho-data-refinery/pull/110
* https://github.com/webdetails/cda/pull/268
* https://github.com/webdetails/cde/pull/886
* https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/631
* https://github.com/pentaho/pentaho-det/pull/1221
* https://github.com/pentaho/pentaho-det-ee/pull/547
* https://github.com/pentaho/pentaho-karaf-assembly/pull/461
* https://github.com/pentaho/big-data-plugin/pull/1428
* https://github.com/pentaho/pentaho-platform/pull/4161
* https://github.com/pentaho/pentaho-ee/pull/1285
* https://github.com/pentaho/pentaho-reporting/pull/1161

**Do not merge without checking the status of the JIRA case.**
