### PR TITLE
[SP-4827] - Backport of PPP-4266 - Use of Vulnerable Component: commons-fileupload-1.3.2.jar (CVE-2016-1000031 | sonatype-2014-01730) (7.1 Suite)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
 
     <dom4j.version>2.1.1</dom4j.version>
     <jaxen.version>1.1.6</jaxen.version>
+    <commons-fileupload.version>1.3.3</commons-fileupload.version>
 
     <!-- PHASE BINDINGS -->
     <set-highest-basedir-phase>initialize</set-highest-basedir-phase>
@@ -182,6 +183,12 @@
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
         <version>${jaxen.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-fileupload</groupId>
+        <artifactId>commons-fileupload</artifactId>
+        <version>${commons-fileupload.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This is a series of PRs:
- https://github.com/pentaho/maven-parent-poms/pull/86
- https://github.com/pentaho/big-data-plugin/pull/1607
- https://github.com/pentaho/data-access/pull/1036
- 