### PR TITLE
[PPP-4271] - Fixed Use of Vulnerable Component: xercesImpl-2.11.0 and…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,9 @@
     <spring-security-kerberos.version>1.0.1.RELEASE</spring-security-kerberos.version>
     <karaf-springframework-override.version>4.1.9.RELEASE_1</karaf-springframework-override.version>
 
+    <xercesImpl.version>2.12.0</xercesImpl.version>
+    <xml-apis.version>1.4.01</xml-apis.version>
+
     <!-- jdk version -->
     <source.jdk.version>1.8</source.jdk.version>
     <target.jdk.version>1.8</target.jdk.version>
@@ -499,6 +502,18 @@
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-redshift</artifactId>
         <version>${aws-java-sdk.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <version>${xercesImpl.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <version>${xml-apis.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
… xercesImpl-2.9.1 (CVE-2013-4002 | CVE-2012-0881 | CVE-2009-2625 | sonatype-2017-0348)

This is a series of PRs to update Apache Xerces to version 2.12.0.

1. https://github.com/pentaho/maven-parent-poms/pull/120
2. https://github.com/pentaho/pentaho-karaf-assembly/pull/536
3. https://github.com/pentaho/pentaho-platform/pull/4397
4. https://github.com/pentaho/mondrian/pull/1117
5. https://github.com/pentaho/pentaho-hadoop-shims/pull/942
6. https://github.com/pentaho/pentaho-reporting/pull/1254
7. https://github.com/pentaho/pentaho-mongodb-plugin/pull/184
8. https://github.com/pentaho/pdi-dataservice-server-plugin/pull/370
9. https://github.com/pentaho/data-access/pull/1052
10. https://github.com/webdetails/cda/pull/309
11. https://github.com/webdetails/cgg/pull/141
12. https://github.com/pentaho/pdi-dataservice-plugin/pull/179
13. https://github.com/pentaho/pentaho-big-data-ee/pull/351
14. https://github.com/pentaho/pentaho-data-refinery/pull/120
15. https://github.com/pentaho/pentaho-platform-plugin-geo/pull/316
16. https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/749
17. https://github.com/pentaho/pentaho-yarn-kettle-plugin/pull/371
18. https://github.com/pentaho/pdi-sdk-plugins/pull/73

@pentaho-lmartins 