### PR TITLE
[BACKLOG-28357] Updates Apache Derby version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,8 @@
 
     <activemq.version>5.10.1</activemq.version>
 
+    <derby.version>10.15.1.3</derby.version>
+
     <jacoco-maven-plugin.version>0.8.1</jacoco-maven-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>


### PR DESCRIPTION
Removal of the Apache Derby version in favor of retrieving a unified version from the Maven parent POM. At the time of this PR, the latest version of Apache Derby is 10.15.1.3.