### PR TITLE
[SP-5046] [PPP-4271] - Fixed Use of Vulnerable Component: xercesImpl-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,9 @@
     <!-- spring-security version -->
     <spring-security.version>4.1.5.RELEASE</spring-security.version>
 
+    <xercesImpl.version>2.12.0</xercesImpl.version>
+    <xml-apis.version>1.4.01</xml-apis.version>
+
     <!-- jdk version -->
     <source.jdk.version>1.8</source.jdk.version>
     <target.jdk.version>1.8</target.jdk.version>
@@ -341,6 +344,16 @@
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-redshift</artifactId>
         <version>${aws-java-sdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <version>${xercesImpl.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <version>${xml-apis.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
…2.11.0 and xercesImpl-2.9.1 (CVE-2013-4002 | CVE-2012-0881 | CVE-2009-2625 | sonatype-2017-0348)  (8.2 Suite)

@ssamora 

This is a series of PRs to update Apache Xerces to version 2.12.0.

1. https://github.com/pentaho/maven-parent-poms/pull/128
2. https://github.com/pentaho/pentaho-karaf-assembly/pull/542
3. https://github.com/pentaho/pentaho-platform/pull/4420
4. https://github.com/pentaho/mondrian/pull/1122
5. https://github.com/pentaho/pentaho-hadoop-shims/pull/951
6. https://github.com/pentaho/pentaho-reporting/pull/1262
7. https://github.com/pentaho/pentaho-mongodb-plugin/pull/185
8. https://github.com/pentaho/pdi-dataservice-server-plugin/pull/371
9. https://github.com/pentaho/data-access/pull/1056
10. https://github.com/webdetails/cda/pull/311
11. https://github.com/webdetails/cgg/pull/143
12. https://github.com/pentaho/pdi-dataservice-plugin/pull/180
13. https://github.com/pentaho/pentaho-big-data-ee/pull/356
14. https://github.com/pentaho/pentaho-data-refinery/pull/121
15. https://github.com/pentaho/pentaho-platform-plugin-geo/pull/317
16. https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/752
17. https://github.com/pentaho/pentaho-yarn-kettle-plugin/pull/375
18. https://github.com/pentaho/pdi-sdk-plugins/pull/75