### PR TITLE
[SP-5030] - Backport of PPP-4335 - Use of Vulnerable Component: com.f…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <rjs.version>2.3.5</rjs.version>
 
     <codehaus-jackson.version>1.9.13</codehaus-jackson.version>
-    <fasterxml-jackson.version>2.9.5</fasterxml-jackson.version>
+    <fasterxml-jackson.version>2.9.8</fasterxml-jackson.version>
     <dom4j.version>2.1.1</dom4j.version>
     <jaxen.version>1.1.6</jaxen.version>
     <commons-fileupload.version>1.3.3</commons-fileupload.version>
@@ -297,6 +297,11 @@
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-cbor</artifactId>
+        <version>${fasterxml-jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.jr</groupId>
+        <artifactId>jackson-jr-objects</artifactId>
         <version>${fasterxml-jackson.version}</version>
       </dependency>
 


### PR DESCRIPTION
…asterxml.jackson.core:jackson-databind (CVE-2018-19360 | CVE-2018-19361 | CVE-2018-14720 | CVE-2018-19362 | CVE-2018-14719 | CVE-2018-14718 | CVE-2018-14721) (8.2 Suite)

- Parent POM - Cherry pick of https://github.com/pentaho/maven-parent-poms/pull/117
**The Parent POM should be merged in first place**


- Child POMs PRs:
https://github.com/webdetails/cda/pull/312
https://github.com/webdetails/cpk/pull/81
https://github.com/webdetails/sparkl/pull/86
https://github.com/pentaho/maven-project-archetypes/pull/15
https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/753
https://github.com/pentaho/pentaho-yarn-kettle-plugin/pull/376
https://github.com/pentaho/big-data-plugin/pull/1680
https://github.com/pentaho/pentaho-ee/pull/2090

Commit https://github.com/pentaho/pentaho-data-profiling-ee/commit/b18eea384be1a36b7a0c4480a8be943089f4da35 haven't been back ported because it doesn't exist 8.2 branch for this repository