### PR TITLE
[PDI-17794] Warnings in Spoon console due to wrong version of log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <!-- VERSIONS -->
 
     <slf4j.version>1.7.7</slf4j.version>
+    <log4j.version>1.2.17</log4j.version>
     <postgresql.version>42.2.5</postgresql.version>
 
     <!-- We are using Felix Framework 4.2.1, which is partially OSGi 5.0 complaint. In particular,
@@ -283,7 +284,16 @@
         <artifactId>slf4j-log4j12</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>apache-log4j-extras</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @wseyler 

* [PDI-17794] Adding Log4J reference to top-level parent pom file.
* [PDI-17794] Adding Apache Log4J Extras reference to top-level parent pom file.

This pull request is part of a series of pull requests:
- https://github.com/pentaho/maven-parent-poms/pull/134
- https://github.com/pentaho/big-data-plugin/pull/1682
- https://github.com/webdetails/cdf/pull/1075
- https://github.com/webdetails/cpf/pull/144
- https://github.com/webdetails/cpk/pull/82
- https://github.com/pentaho/data-access/pull/1060
- https://github.com/pentaho/maven-project-archetypes/pull/16
- https://github.com/pentaho/maven-project-archetypes-ee/pull/35
- https://github.com/pentaho/modeler/pull/356
- https://github.com/pentaho/mondrian/pull/1125
- https://github.com/pentaho/pdi-monitoring-plugin/pull/95
- https://github.com/pentaho/pdi-palo-core/pull/13
- https://github.com/pentaho/pentaho-analysis-ee/pull/33
- https://github.com/pentaho/pentaho-dashboard-chart-editor/pull/63
- https://github.com/pentaho/pentaho-ee/pull/2104
- https://github.com/pentaho/pentaho-ee-license/pull/62
- https://github.com/pentaho/pentaho-hadoop-shims/pull/954
- https://github.com/pentaho/pentaho-kettle/pull/6514
- https://github.com/pentaho/pentaho-metadata/pull/201
- https://github.com/pentaho/pentaho-metadata-editor/pull/166
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/60
- https://github.com/pentaho/pentaho-metaverse/pull/596
- https://github.com/pentaho/pentaho-platform/pull/4428
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/318
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/754
- https://github.com/pentaho/pentaho-platform-plugin-jpivot/pull/72
- https://github.com/pentaho/pentaho-reporting/pull/1269
- https://github.com/pentaho/qa-automation/pull/4969