### PR TITLE
Revert "[PPP-4295] - Change to the parent pom to use non-vulnerable version o…"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 
     <cxf.version>3.1.9</cxf.version>
 
-    <activemq.version>5.15.8</activemq.version>
+    <activemq.version>5.10.1</activemq.version>
 
     <derby.version>10.14.2.0</derby.version>
 


### PR DESCRIPTION
Reverts pentaho/maven-parent-poms#136

@ssamora 