### PR TITLE
[PPP-4400] Use of Vulnerable Component: logback-classic-1.1.11.jar (CVE-2017-5929)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <!-- VERSIONS -->
 
     <slf4j.version>1.7.7</slf4j.version>
+    <logback.version>1.2.0</logback.version>
     <postgresql.version>42.2.5</postgresql.version>
 
     <!-- We are using Felix Framework 4.2.1, which is partially OSGi 5.0 complaint. In particular,
@@ -284,7 +285,16 @@
         <artifactId>slf4j-log4j12</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>


### PR DESCRIPTION
@pentaho/tatooine  @pentaho-lmartins @wseyler

* [PPP-4400] Moving dependency reference and version info to the maven-parent-pom repo

This Pull Request is part of a series of Pull Requests:
- https://github.com/pentaho/maven-parent-poms/pull/145
- https://github.com/pentaho/pdi-osgi-bridge/pull/73
- https://github.com/pentaho/pdi-monitoring-plugin/pull/96
- https://github.com/pentaho/pentaho-ee/pull/2128
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/227
- https://github.com/pentaho/pentaho-osgi-bundles/pull/324