### PR TITLE
[SP-5146] Backport of PPP-4400 - Use of Vulnerable Component: logback-classic-1.1.11.jar (CVE-2017-5929) (7.1 Suite)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
   <properties>
     
     <!-- VERSIONS -->
+    <logback.version>1.2.0</logback.version>
     <postgresql.version>42.2.5</postgresql.version>
     <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
     <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
@@ -178,6 +179,16 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @LeonardoCoelho71950

This PR is a part of a set of PRs (pentaho-ee was not backported as the relevant file was added in version 8.0+):
- https://github.com/pentaho/maven-parent-poms/pull/150
- https://github.com/pentaho/pdi-osgi-bridge/pull/77
- https://github.com/pentaho/pdi-monitoring-plugin/pull/98
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/229
- https://github.com/pentaho/pentaho-osgi-bundles/pull/326