### PR TITLE
[SP-5149] Backport of PPP-4401 - Use of Vulnerable Component: bootstrap-3.3.6.jar (CVE-2019-8331 | CVE-2018-20677 | CVE-2018-20676) (8.3 Suite)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
     <nodejs.version>v10.0.0</nodejs.version>
     <npm.version>5.7.1</npm.version>
     <requirejs.version>2.3.6</requirejs.version>
+    <bootstrap.version>3.4.1</bootstrap.version>
 
     <codehaus-jackson.version>1.9.13</codehaus-jackson.version>
     <fasterxml-jackson.version>2.9.8</fasterxml-jackson.version>
@@ -532,6 +533,12 @@
         <groupId>org.webjars.npm</groupId>
         <artifactId>requirejs</artifactId>
         <version>${requirejs.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>bootstrap</artifactId>
+        <version>${bootstrap.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @LeonardoCoelho71950 

This PR is part of a set of PRs:
- https://github.com/pentaho/maven-parent-poms/pull/152
- https://github.com/pentaho/pentaho-det/pull/1320
- https://github.com/pentaho/pentaho-det-ee/pull/595