### PR TITLE
Revert "[PDI-17794] Warnings in Spoon console due to wrong version of log4j"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
 
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.2.0</logback.version>
-    <log4j.version>1.2.17</log4j.version>
     <postgresql.version>42.2.5</postgresql.version>
 
     <!-- We are using Felix Framework 4.2.1, which is partially OSGi 5.0 complaint. In particular,
@@ -297,16 +296,6 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logback.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>apache-log4j-extras</artifactId>
-        <version>${log4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>


### PR DESCRIPTION
Reverts pentaho/maven-parent-poms#137

Because of conflicts with pentaho-hadoop-shims-cdh512