### PR TITLE
[PDI-17667] Use of vulnerable component jetty 8.1.15, CVE-2017-9735, …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
     <commons-compress.version>1.18</commons-compress.version>
     <commons-fileupload.version>1.4</commons-fileupload.version>
     <aws-java-sdk.version>1.11.516</aws-java-sdk.version>
+    <jetty.version>8.1.15.v20140411</jetty.version>
 
     <!-- spring version -->
     <spring.version>4.3.22.RELEASE</spring.version>
@@ -281,6 +282,61 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-continuation</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-http</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-io</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-plus</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-security</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-servlet</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-servlets</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-util</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-xml</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-webapp</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -304,12 +304,12 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
+        <artifactId>jetty-security</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-security</artifactId>
+        <artifactId>jetty-server</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
…CVE-2017-7657 CVE-2015-2080

[PPP-4183] Use of Vulnerable Component: Multiple Jetty Components [Listed in Description] (CVE-2017-7656 | CVE-2017-7657 | CVE-2017-7658 | CVE-2015-2080 | CVE-2017-9735 )
[PDI-11851] Improve the jetty server version of Carte Server
[PPP-4402] Use of Vulnerable Component: jetty-server & jetty-util (CVE-2019-10246 | CVE-2019-10247)


To better cope with the synchronization with the Karaf upgrade, it was decided that the Jetty upgrade was to be split into two phases: the first would basically consist on centralizing the Jetty version on the parent POM (leaving the version as it is); the second phase (to be integrated into the Karaf upgrade development) would include the upgrade itself and any other changes required.

This PR belongs to phase 1.

**For this specific PR:**
Centralized Jetty components adding a property for the Jetty version (left it as 8.1.15.v20140411) and making the needed declarations at the dependency management level.

**List of PRs for phase 1:**

- [big-data-plugin#1740](https://github.com/pentaho/big-data-plugin/pull/1740)
- [pdi-monitoring-plugin#99](https://github.com/pentaho/pdi-monitoring-plugin/pull/99)
- [pentaho-hadoop-shims#1006](https://github.com/pentaho/pentaho-hadoop-shims/pull/1006)
- [pentaho-kettle#6860](https://github.com/pentaho/pentaho-kettle/pull/6860)
- [pentaho-platform#4536](https://github.com/pentaho/pentaho-platform/pull/4536)
- [pentaho-reporting#1292](https://github.com/pentaho/pentaho-reporting/pull/1292)
- [cde#948](https://github.com/webdetails/cde/pull/948)



