### PR TITLE
[PPP-4448] Use of Vulnerable Component - XStream 1.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
     <fasterxml-jackson.version>2.9.9</fasterxml-jackson.version>
     <dom4j.version>2.1.1</dom4j.version>
     <jaxen.version>1.1.6</jaxen.version>
+    <xstream.version>1.4.11.1</xstream.version>
     <commons-compress.version>1.18</commons-compress.version>
     <commons-fileupload.version>1.4</commons-fileupload.version>
     <aws-java-sdk.version>1.11.516</aws-java-sdk.version>
@@ -562,6 +563,12 @@
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
         <version>${jaxen.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.thoughtworks.xstream</groupId>
+        <artifactId>xstream</artifactId>
+        <version>${xstream.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Adding dependency management at the parent pom level so we can control which version of XStream we use. Version 1.4.10 contains a security vulnerability which was fixed in 1.4.11.

See change log: http://x-stream.github.io/changes.html (no breaking changes in API)

Upgrading to the latest `1.4.11.1`. This is a series of PRs:

1. https://github.com/pentaho/maven-parent-poms/pull/170 (this PR)
2. https://github.com/pentaho/pentaho-kettle/pull/6928
3. https://github.com/pentaho/pentaho-aggdesigner/pull/120
4. https://github.com/pentaho/pentaho-metadata/pull/206
5. https://github.com/pentaho/pentaho-metadata-editor/pull/180
6. https://github.com/pentaho/pentaho-metadata-editor-ee/pull/74
7. https://github.com/pentaho/mql-editor/pull/61
8. https://github.com/pentaho/pentaho-chartbeans/pull/42
9. https://github.com/pentaho/pentaho-platform/pull/4560
10. https://github.com/pentaho/data-access/pull/1073
11. https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/761
12. https://github.com/pentaho/pentaho-dashboard-chart-editor/pull/68
13. https://github.com/pentaho/pentaho-ee-chart-plugin/pull/16
14. https://github.com/pentaho/pentaho-hadoop-shims/pull/1015
15. https://github.com/pentaho/big-data-plugin/pull/1812
16. https://github.com/pentaho/pentaho-big-data-ee/pull/402

**Ready for review!**

@ssamora @RPAraujo @ppatricio 