### PR TITLE
[SP-5296] Backport of PPP-4448 - Use of Vulnerable Component - XStrea…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
     <fasterxml-jackson.version>2.9.9</fasterxml-jackson.version>
     <dom4j.version>2.1.1</dom4j.version>
     <jaxen.version>1.1.6</jaxen.version>
+    <xstream.version>1.4.11.1</xstream.version>
     <commons-compress.version>1.18</commons-compress.version>
     <commons-fileupload.version>1.4</commons-fileupload.version>
     <aws-java-sdk.version>1.11.516</aws-java-sdk.version>
@@ -485,6 +486,12 @@
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
         <version>${jaxen.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.thoughtworks.xstream</groupId>
+        <artifactId>xstream</artifactId>
+        <version>${xstream.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
…m 1.4.10 (8.3 Suite)
@smmribeiro @gryphendowre 
cherry-pick of #170 
Please merge this PR first.
Note the original PR for master also had a reference pentaho-big-data-ee. In 8.3 pentaho-big-data-ee has no references to XStream
The other related PRs are:
1. #170 (this PR)
2. https://github.com/pentaho/pentaho-kettle/pull/6999
3. https://github.com/pentaho/pentaho-aggdesigner/pull/121
4. https://github.com/pentaho/pentaho-metadata/pull/207
5. https://github.com/pentaho/pentaho-metadata-editor/pull/181
6. https://github.com/pentaho/pentaho-metadata-editor-ee/pull/75
7. https://github.com/pentaho/mql-editor/pull/62
8. https://github.com/pentaho/pentaho-chartbeans/pull/43
9. https://github.com/pentaho/pentaho-platform/pull/4577
10. https://github.com/pentaho/data-access/pull/1075
11. https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/764
12. https://github.com/pentaho/pentaho-dashboard-chart-editor/pull/69
13. https://github.com/pentaho/pentaho-ee-chart-plugin/pull/17
14. https://github.com/pentaho/pentaho-hadoop-shims/pull/1040
15. https://github.com/pentaho/big-data-plugin/pull/1845