### PR TITLE
[PPP-4447] Use of vulnerable component - Tika Core 1.1x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
     <dom4j.version>2.1.1</dom4j.version>
     <jaxen.version>1.1.6</jaxen.version>
     <xstream.version>1.4.11.1</xstream.version>
+    <jackrabbit.version>2.16.5</jackrabbit.version>
     <commons-compress.version>1.18</commons-compress.version>
     <commons-fileupload.version>1.4</commons-fileupload.version>
     <aws-java-sdk.version>1.11.516</aws-java-sdk.version>
@@ -592,6 +593,32 @@
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
         <version>${xstream.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-api</artifactId>
+        <version>${jackrabbit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-core</artifactId>
+        <version>${jackrabbit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-spi</artifactId>
+        <version>${jackrabbit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-spi-commons</artifactId>
+        <version>${jackrabbit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-jcr-commons</artifactId>
+        <version>${jackrabbit.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Replaces #172. This is a series of PRs:

- https://github.com/pentaho/maven-parent-poms/pull/178 (this one)
- https://github.com/pentaho/pentaho-platform/pull/4580
- https://github.com/pentaho/pentaho-kettle/pull/7016
- https://github.com/pentaho/data-access/pull/1076

Updates `jackrabbit-*` to version 2.16.5 and `tika-core` to version 1.22.

@ssamora @RPAraujo 