### PR TITLE
[PPP-4295] Use of Vulnerable Component: activemq-all, activemq-osgi, …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,12 +85,11 @@
     <aries.blueprint.core.version>1.10.2</aries.blueprint.core.version>
 
     <pax-web.version>7.2.10</pax-web.version>
-
     <pax-url-aether.version>2.6.1</pax-url-aether.version>
 
     <cxf.version>3.3.1</cxf.version>
 
-    <activemq.version>5.10.1</activemq.version>
+    <activemq.version>5.15.11</activemq.version>
 
     <derby.version>10.14.2.0</derby.version>
 


### PR DESCRIPTION
…activeio-core, activemq-camel, activemq-karaf (CVE-2018-11775)

Upgrades `activemq` to version 5.15.11.

Merge https://github.com/pentaho/pentaho-kettle/pull/7168 after this one.

@ssamora 