### PR TITLE
[BACKLOG-30710] - update build-helper-maven-plugin

### DIFF
--- a/pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pentaho-ce-bundle-parent-pom/pom.xml
+++ b/pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pentaho-ce-bundle-parent-pom/pom.xml
@@ -228,7 +228,7 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
+            <groupId>org.pentaho</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
             <executions>
               <execution>

--- a/pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pom.xml
+++ b/pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pom.xml
@@ -129,7 +129,7 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
+            <groupId>org.pentaho</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
     <maven-dependency-plugin.version>3.1.0</maven-dependency-plugin.version>
-    <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
+    <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
     <requirejs-maven-plugin.version>2.0.4</requirejs-maven-plugin.version>
     <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
@@ -1176,7 +1176,7 @@
           </dependencies>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>org.pentaho</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>${build-helper-maven-plugin.version}</version>
         </plugin>
@@ -1235,7 +1235,7 @@
         <artifactId>maven-release-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.pentaho</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
           <execution>
@@ -1301,7 +1301,7 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
+            <groupId>org.pentaho</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
             <executions>
               <execution>
@@ -1903,7 +1903,7 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
+            <groupId>org.pentaho</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
             <executions>
               <execution>


### PR DESCRIPTION
This will update `build-helper-maven-plugin` to our custom build which fixes the `rootlocation` goal.