### PR TITLE
[PPP-4459] Use of Vulnerable Component: org.eclipse.paho:org.eclipse.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@
     <jetty.version>9.4.18.v20190429</jetty.version>
     <httpclient.version>4.5.9</httpclient.version>
     <httpcore.version>4.4.11</httpcore.version>
+    <paho.version>1.2.2</paho.version>
 
     <!-- spring version -->
     <spring.version>4.3.22.RELEASE</spring.version>
@@ -702,6 +703,12 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore-osgi</artifactId>
         <version>${httpcore.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.paho</groupId>
+        <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+        <version>${paho.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
…paho.client.mqttv3: CVE-2019-11777

This is a series of PRs to update `org.eclipse.paho.client.mqttv3` to version **1.2.2**.

PRs:
1. https://github.com/pentaho/maven-parent-poms/pull/202 (this PR)
2. https://github.com/pentaho/pentaho-kettle/pull/7248
3. https://github.com/pentaho/pentaho-reporting/pull/1320
4. https://github.com/pentaho/pentaho-platform/pull/4632
5. https://github.com/pentaho/pentaho-reportdesigner-ee/pull/150
6. https://github.com/pentaho/adaptive-execution-layer/pull/149

Please review and merge @ssamora @ppatricio 
