### PR TITLE
[PPP-4461] Use of Vulnerable Component: com.fasterxml.jackson.core:ja…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,8 @@
     <fancyapps__fancybox.version>3.5.5</fancyapps__fancybox.version>
 
     <codehaus-jackson.version>1.9.13</codehaus-jackson.version>
-    <fasterxml-jackson.version>2.10.2</fasterxml-jackson.version>
+    <fasterxml-jackson.version>2.9.10</fasterxml-jackson.version>
+    <fasterxml-jackson-databind.version>2.9.10.2</fasterxml-jackson-databind.version>
     <dom4j.version>2.1.1</dom4j.version>
     <jaxen.version>1.1.6</jaxen.version>
     <xstream.version>1.4.11.1</xstream.version>
@@ -543,7 +544,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${fasterxml-jackson.version}</version>
+        <version>${fasterxml-jackson-databind.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>


### PR DESCRIPTION
…ckson-databind: CVE-2019-16943 and others

Follow-up to https://github.com/pentaho/maven-parent-poms/pull/201.
Downgrading `fasterxml-jackson` to 2.9.10 and `jackson-databind` to 2.9.10.2.

This addresses the CVE and avoids JPMS issues.

@graimundo 