### PR TITLE
[CLEANUP] add custom CI surefire/failsafe argLine configuration.

### DIFF
--- a/pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pom.xml
+++ b/pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pom.xml
@@ -34,14 +34,17 @@
     <junit.version>4.11</junit.version>
 
     <!-- http://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html -->
+    <maven.test.failure.ignore>false</maven.test.failure.ignore>
     <maven-surefire-plugin.reuseForks>true</maven-surefire-plugin.reuseForks>   <!-- default setting is reuseForks = true -->
     <maven-surefire-plugin.forkCount>1</maven-surefire-plugin.forkCount>        <!-- default setting is forkCount = 1 -->
     <maven-surefire-plugin.testFailureIgnore>${maven.test.failure.ignore}</maven-surefire-plugin.testFailureIgnore>
     <maven-surefire-plugin.argLine/>
+    <maven-surefire-plugin.ci.argLine/>
     <maven-failsafe-plugin.reuseForks>true</maven-failsafe-plugin.reuseForks>   <!-- default setting is reuseForks = true -->
     <maven-failsafe-plugin.forkCount>1</maven-failsafe-plugin.forkCount>        <!-- default setting is forkCount = 1 -->
     <maven-failsafe-plugin.testFailureIgnore>${maven.test.failure.ignore}</maven-failsafe-plugin.testFailureIgnore>
     <maven-failsafe-plugin.argLine/>
+    <maven-failsafe-plugin.ci.argLine/>
 
     <SCM_BRANCH>master</SCM_BRANCH>
     
@@ -61,7 +64,7 @@
               <goal>test</goal>
             </goals>
             <configuration>
-              <argLine>-Dfile.encoding=${project.build.sourceEncoding} @{jacocoSurefireArgLine} ${maven-surefire-plugin.argLine}</argLine>
+              <argLine>-Dfile.encoding=${project.build.sourceEncoding} @{jacocoSurefireArgLine} ${maven-surefire-plugin.argLine} ${maven-surefire-plugin.ci.argLine}</argLine>
               <forkCount>${maven-surefire-plugin.forkCount}</forkCount>
               <reuseForks>${maven-surefire-plugin.reuseForks}</reuseForks>
               <testFailureIgnore>${maven-surefire-plugin.testFailureIgnore}</testFailureIgnore>
@@ -183,7 +186,7 @@
               </execution>
             </executions>
             <configuration>
-              <argLine>-Dfile.encoding=${project.build.sourceEncoding} @{jacocoFailsafeArgLine} ${maven-failsafe-plugin.argLine}</argLine>
+              <argLine>-Dfile.encoding=${project.build.sourceEncoding} @{jacocoFailsafeArgLine} ${maven-failsafe-plugin.argLine} ${maven-failsafe-plugin.ci.argLine}</argLine>
               <forkCount>${maven-failsafe-plugin.forkCount}</forkCount>
               <reuseForks>${maven-failsafe-plugin.reuseForks}</reuseForks>
               <testClassesDirectory>${project.build.directory}/it-classes</testClassesDirectory>


### PR DESCRIPTION
@pentaho/x-wing Wingman needs to set extra JVM args for forked surefire/failsafe executions, but the way it implemented is overriding any project's custom arguments. 

This adds a dedicated CI place to add configurations without overriding the project ones.