### PR TITLE
[BACKLOG-33393] Add version properties for the angular and ui-router …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,9 @@
      -->
     <angular.version>1.7.8</angular.version>
     <angular-translate.version>2.18.1</angular-translate.version>
+    <angular-ui-bootstrap-bower.version>1.3.3</angular-ui-bootstrap-bower.version>
+    <uirouter-core.version>5.0.23</uirouter-core.version>
+    <uirouter-angularjs.version>1.0.22</uirouter-angularjs.version>
 
     <fancyapps__fancybox.version>3.5.5</fancyapps__fancybox.version>
 
@@ -749,6 +752,79 @@
         <groupId>org.webjars.npm</groupId>
         <artifactId>jquery</artifactId>
         <version>${jquery.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.webjars.bower</groupId>
+        <artifactId>angular</artifactId>
+        <version>${angular.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>angular-i18n</artifactId>
+        <version>${angular.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.bower</groupId>
+        <artifactId>angular-translate</artifactId>
+        <version>${angular-translate.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.bower</groupId>
+        <artifactId>angular-route</artifactId>
+        <version>${angular.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.bower</groupId>
+        <artifactId>angular-sanitize</artifactId>
+        <version>${angular.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.bower</groupId>
+        <artifactId>angular-animate</artifactId>
+        <version>${angular.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.bower</groupId>
+        <artifactId>angular-ui-bootstrap-bower</artifactId>
+        <version>${angular-ui-bootstrap-bower.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>angular-mocks</artifactId>
+        <version>${angular.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>uirouter__core</artifactId>
+        <version>${uirouter-core.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>uirouter__angularjs</artifactId>
+        <version>${uirouter-angularjs.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
…et. al. libraries to the parent pom, along with their dependencyManagement counterparts.

For angular-i18n and angular-mocks, the webjar of NPM flavour was preferred.

@pentaho/millenniumfalcon please review.
/cc @pentaho/r2d2

Merge with:
* https://github.com/pentaho/pentaho-osgi-bundles/pull/354
* https://github.com/pentaho/pentaho-det/pull/1336
* https://github.com/pentaho/pentaho-det-ee/pull/612
* https://github.com/pentaho/pentaho-analyzer/pull/2071