### PR TITLE
[PPP-4486] Use of Vulnerable Component: commons-codec [Multiple Versi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
     <commons-compress.version>1.18</commons-compress.version>
     <commons-fileupload.version>1.4</commons-fileupload.version>
     <commons-vfs2.version>2.3</commons-vfs2.version>
+    <commons-codec.version>1.14</commons-codec.version>
     <aws-java-sdk.version>1.11.516</aws-java-sdk.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <httpclient.version>4.5.9</httpclient.version>
@@ -645,6 +646,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-vfs2</artifactId>
         <version>${commons-vfs2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>${commons-codec.version}</version>
       </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
…ons] (sonatype-2012-0050)

Bumping `commons-codec` to version 1.14 to address multiple CVEs.

This is a series of PRs:
1. https://github.com/pentaho/maven-parent-poms/pull/214 (this)
2. https://github.com/webdetails/cda/pull/337
3. https://github.com/pentaho/data-access/pull/1089
4. https://github.com/pentaho/marketplace/pull/177
5. https://github.com/pentaho/adaptive-execution-layer/pull/152
6. https://github.com/pentaho/pentaho-kettle/pull/7268
7. https://github.com/pentaho/pentaho-s3-vfs/pull/92
8. https://github.com/pentaho/pentaho-det-ee/pull/613
9. https://github.com/pentaho/pentaho-platform/pull/4637
10. https://github.com/pentaho/pentaho-metadata-editor/pull/189
11. https://github.com/pentaho/pentaho-metadata-editor-ee/pull/84
12. https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/788
13. https://github.com/pentaho/pentaho-reporting/pull/1325
14. https://github.com/pentaho/pdi-ee-plugin/pull/385
15. https://github.com/pentaho/pentaho-versionchecker/pull/23
16. https://github.com/pentaho/modeler/pull/363
17. https://github.com/pentaho/metastore/pull/65
18. https://github.com/pentaho/pdi-scheduler-plugin/pull/81
19. https://github.com/pentaho/pentaho-ee-license/pull/71
20. https://github.com/pentaho/pdi-plugins-ee/pull/164
21. https://github.com/pentaho/pentaho-analysis-ee/pull/34
22. https://github.com/pentaho/dataflow-manager/pull/572

Please review and approve but **do not merge**!

@ssamora @ppatricio @smmribeiro @bcostahitachivantara 