### PR TITLE
[SP-5410] Backport of PPP-4459 - Use of Vulnerable Component: org.ecl…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
     <jetty.version>9.4.18.v20190429</jetty.version>
     <httpclient.version>4.5.9</httpclient.version>
     <httpcore.version>4.4.11</httpcore.version>
+    <paho.version>1.2.2</paho.version>
 
     <!-- spring version -->
     <spring.version>4.3.22.RELEASE</spring.version>
@@ -701,6 +702,12 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore-osgi</artifactId>
         <version>${httpcore.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.paho</groupId>
+        <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+        <version>${paho.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
…ipse.paho:org.eclipse.paho.client.mqttv3: CVE-2019-11777 (9.0 Suite)

Cherry-pick of https://github.com/pentaho/maven-parent-poms/pull/202 into 9.0 branch.

PRs:
1. https://github.com/pentaho/maven-parent-poms/pull/215 (this)
2. https://github.com/pentaho/pentaho-kettle/pull/7274
3. https://github.com/pentaho/pentaho-reporting/pull/1326
4. https://github.com/pentaho/pentaho-platform/pull/4641
5. https://github.com/pentaho/pentaho-reportdesigner-ee/pull/151
6. https://github.com/pentaho/adaptive-execution-layer/pull/153

@ppatricio 