### PR TITLE
[PPP-4496] Use of Vulnerable Component: Components/kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@
     <jetty.version>9.4.18.v20190429</jetty.version>
     <httpclient.version>4.5.9</httpclient.version>
     <httpcore.version>4.4.11</httpcore.version>
+    <kafka-clients.version>0.10.2.2</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
     <tomcat.version>8.5.50</tomcat.version>
 
@@ -708,6 +709,12 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore-osgi</artifactId>
         <version>${httpcore.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${kafka-clients.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
* [PPP-4496] Upgrading to version 0.10.2.2
* [PPP-4496] Moving version reference here for other projects to utilize

This is from a series of Pull Requests:
- https://github.com/pentaho/maven-parent-poms/pull/218
- https://github.com/pentaho/big-data-plugin/pull/2032
- https://github.com/pentaho/pdi-plugins-ee/pull/168
- https://github.com/pentaho/pentaho-platform/pull/4649
- https://github.com/pentaho/pentaho-reporting/pull/1327
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/152
- https://github.com/pentaho/pentaho-metadata-editor/pull/190
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/85
- https://github.com/pentaho/pentaho-kettle/pull/7309
- https://github.com/pentaho/pentaho-big-data-ee/pull/441