### PR TITLE
[PPP-4506] Use of Vulnerable component - Tomcat 8.5.50 - CVE-2020-1938

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
     <httpcore.version>4.4.11</httpcore.version>
     <kafka-clients.version>0.10.2.2</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
-    <tomcat.version>8.5.50</tomcat.version>
+    <tomcat.version>8.5.51</tomcat.version>
 
     <!-- spring version -->
     <spring.version>4.3.22.RELEASE</spring.version>


### PR DESCRIPTION
Bumping tomcat version to 8.5.51 to address CVE-2020-1938.

@ssamora 