### PR TITLE
Revert "Merge pull request #220 from gryphendowre/SP-5370"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,6 @@
     <jackrabbit.version>2.16.5</jackrabbit.version>
     <commons-compress.version>1.18</commons-compress.version>
     <commons-fileupload.version>1.4</commons-fileupload.version>
-    <commons-vfs2.version>2.3</commons-vfs2.version>
     <aws-java-sdk.version>1.11.516</aws-java-sdk.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <httpclient.version>4.5.9</httpclient.version>
@@ -641,11 +640,7 @@
         <artifactId>commons-fileupload</artifactId>
         <version>${commons-fileupload.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-vfs2</artifactId>
-        <version>${commons-vfs2.version}</version>
-      </dependency>
+
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-core</artifactId>


### PR DESCRIPTION
This reverts commit dd998a842948fa7b27ab91c324417065baa5d690, reversing
changes made to 7311a5827e06a2002395bbabd78a9ab8a10b2418.

This Revert PR is part of a series:
- https://github.com/pentaho/maven-parent-poms/pull/229
- https://github.com/pentaho/apache-vfs-browser/pull/62
- https://github.com/pentaho/big-data-plugin/pull/2040
- https://github.com/webdetails/cpk/pull/87
- https://github.com/pentaho/data-access/pull/1091
- https://github.com/pentaho/mondrian/pull/1202
- https://github.com/pentaho/pdi-jms-plugin/pull/76
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/104
- https://github.com/pentaho/pdi-plugins-ee/pull/174
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/84
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/53
- https://github.com/pentaho/pentaho-big-data-ee/pull/444
- https://github.com/pentaho/pentaho-commons-database/pull/179
- https://github.com/pentaho/pentaho-data-mining/pull/26
- https://github.com/pentaho/pentaho-det-ee/pull/616
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/23
- https://github.com/pentaho/pentaho-karaf-assembly/pull/635
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/290
- https://github.com/pentaho/pentaho-kettle/pull/7334
- https://github.com/pentaho/pentaho-metaverse/pull/621
- https://github.com/pentaho/pentaho-osgi-bundles/pull/363
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1504
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/341
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/790
- https://github.com/pentaho/pentaho-platform/pull/4658
- https://github.com/pentaho/pentaho-reporting/pull/1342
- https://github.com/pentaho/pentaho-s3-vfs/pull/94
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/17