### PR TITLE
[PPP-4494] Use of vulnerable component 'commons-compress' version 1.1…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <jaxen.version>1.1.6</jaxen.version>
     <xstream.version>1.4.11.1</xstream.version>
     <jackrabbit.version>2.16.5</jackrabbit.version>
-    <commons-compress.version>1.18</commons-compress.version>
+    <commons-compress.version>1.20</commons-compress.version>
     <commons-fileupload.version>1.4</commons-fileupload.version>
     <commons-vfs2.version>2.3</commons-vfs2.version>
     <commons-codec.version>1.14</commons-codec.version>


### PR DESCRIPTION
…8 (CVE-2019-12402)

Bumping `commons-compress` to version **1.20** to address CVE-2019-12402.

@ssamora 