### PR TITLE
[PPP-4497] Use of vulnerable component jstl version 1.0.5 (CVE-2015-0…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,9 @@
     <kafka-clients.version>0.10.2.2</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
     <tomcat.version>8.5.51</tomcat.version>
+    <taglibs-standard.version>1.2.5</taglibs-standard.version>
+    <servlet-api.version>2.5</servlet-api.version>
+    <jsp-api.version>2.1</jsp-api.version>
 
     <!-- spring version -->
     <spring.version>4.3.22.RELEASE</spring.version>
@@ -737,6 +740,27 @@
         <groupId>org.eclipse.paho</groupId>
         <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
         <version>${paho.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>servlet-api</artifactId>
+        <version>${servlet-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.servlet.jsp</groupId>
+        <artifactId>jsp-api</artifactId>
+        <version>${jsp-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.taglibs</groupId>
+        <artifactId>taglibs-standard-spec</artifactId>
+        <version>${taglibs-standard.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.taglibs</groupId>
+        <artifactId>taglibs-standard-impl</artifactId>
+        <version>${taglibs-standard.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
…254)

Upgrading `javax.servlet:jstl` to `org.apache.taglibs:taglibs-standard-*` version **1.2.5** to address [CVE-2015-0254](https://nvd.nist.gov/vuln/detail/CVE-2015-0254). Also upgrading provided dependencies `javax.servlet:servlet-api` and `javax.servlet.jsp:jsp-api`.

This is related with:
1. https://github.com/pentaho/pentaho-platform-plugin-jpivot/pull/77
2. https://github.com/pentaho/pentaho-platform/pull/4671
3. https://github.com/pentaho/pentaho-karaf-assembly/pull/636
4. https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/291

Please review and merge.

@ssamora @ppatricio