### PR TITLE
[SP-5527] Backport of PPP-4486 - Use of Vulnerable Component: commons…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
     <jackrabbit.version>2.16.5</jackrabbit.version>
     <commons-compress.version>1.18</commons-compress.version>
     <commons-fileupload.version>1.4</commons-fileupload.version>
+    <commons-codec.version>1.14</commons-codec.version>
     <aws-java-sdk.version>1.11.516</aws-java-sdk.version>
     <tomcat.version>8.5.51</tomcat.version>
 
@@ -544,6 +545,11 @@
         <version>${commons-fileupload.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>${commons-codec.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-core</artifactId>


### PR DESCRIPTION
…-codec [Multiple Versions] (sonatype-2012-0050) (8.3 Suite)

cherry-pick of 5cc34d8b8f6add826e7f8e3f597b97af9c5dcba1

@pentaho-lmartins @ppatricio @bcostahitachivantara @smmribeiro 

Related PRs:
https://github.com/pentaho/maven-parent-poms/pull/233
https://github.com/webdetails/cda/pull/338
https://github.com/pentaho/data-access/pull/1092
https://github.com/pentaho/marketplace/pull/181
https://github.com/pentaho/adaptive-execution-layer/pull/162
https://github.com/pentaho/pentaho-kettle/pull/7393
https://github.com/pentaho/pentaho-s3-vfs/pull/102
https://github.com/pentaho/pentaho-det-ee/pull/617
https://github.com/pentaho/pentaho-platform/pull/4677
https://github.com/pentaho/pentaho-metadata-editor/pull/191
https://github.com/pentaho/pentaho-metadata-editor-ee/pull/86
https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/791
https://github.com/pentaho/pentaho-reporting/pull/1344
https://github.com/pentaho/pdi-ee-plugin/pull/387
https://github.com/pentaho/pentaho-versionchecker/pull/24
https://github.com/pentaho/modeler/pull/364
https://github.com/pentaho/metastore/pull/66
https://github.com/pentaho/pdi-scheduler-plugin/pull/82
https://github.com/pentaho/pentaho-ee-license/pull/73
https://github.com/pentaho/pdi-plugins-ee/pull/181
https://github.com/pentaho/pentaho-analysis-ee/pull/35