### PR TITLE
[BACKLOG-33815] - Added profile to create and attach artifact with proto specification files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2031,6 +2031,48 @@
     </profile>
 
     <profile>
+      <!-- Creates and attaches a zip artifact with all proto definition files. -->
+      <id>proto-sources-artifact</id>
+
+      <activation>
+        <file>
+          <exists>${basedir}/src/main/proto</exists>
+        </file>
+      </activation>
+
+      <properties>
+        <proto.sources.artifact.file>${project.build.directory}/${project.build.finalName}-proto.zip</proto.sources.artifact.file>
+      </properties>
+
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>zip-proto-sources-and-attach-artifact</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <target>
+                    <zip destfile="${proto.sources.artifact.file}"
+                         basedir="${basedir}/src/main/proto"
+                         includes="**/*.proto"/>
+                    <attachartifact file="${proto.sources.artifact.file}"
+                                    type="zip"
+                                    classifier="proto"/>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>eula-wrap</id>
       <activation>
         <property>


### PR DESCRIPTION
Although I'm not a fan of using ant from maven in this case I found it troublesome to use a combination of the assembly plugin for zipping and build-helper to attach the artifact.
AFAIK the assembly plugin does not allow having the assembly descriptor to be inline in the POM. It requires the assembly descriptors to be defined externally in a dedicated file(s). This external descriptor would not seamlessly "pass along" to the descendant POMs where the profile will be activated.

With the maven antrun plugin we are able to achieve the goal with a clean and simple solution. 
Let me know if there is a better alternative. 