### PR TITLE
[SP-5528] Backport of PPP-4486 - Use of Vulnerable Component: commons…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
     <commons-compress.version>1.18</commons-compress.version>
     <commons-fileupload.version>1.4</commons-fileupload.version>
     <commons-vfs2.version>2.3</commons-vfs2.version>
+    <commons-codec.version>1.14</commons-codec.version>
     <aws-java-sdk.version>1.11.516</aws-java-sdk.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <httpclient.version>4.5.9</httpclient.version>
@@ -646,6 +647,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-vfs2</artifactId>
         <version>${commons-vfs2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>${commons-codec.version}</version>
       </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
…-codec [Multiple Versions] (sonatype-2012-0050) (9.0 Suite)

Bumping `commons-codec` to version **1.14** to address multiple CVEs.
Cherry-pick of #214 into 9.0 branch.

This is a series of PRs:
1. https://github.com/pentaho/maven-parent-poms/pull/238 (this)
2. https://github.com/pentaho/pentaho-ee-license/pull/76
3. https://github.com/webdetails/cda/pull/341
4. https://github.com/pentaho/data-access/pull/1094
5. https://github.com/pentaho/marketplace/pull/182
6. https://github.com/pentaho/adaptive-execution-layer/pull/165
7. https://github.com/pentaho/pentaho-kettle/pull/7486
8. https://github.com/pentaho/pentaho-s3-vfs/pull/114
9. https://github.com/pentaho/pentaho-det-ee/pull/620
10. https://github.com/pentaho/pentaho-platform/pull/4697
11. https://github.com/pentaho/pentaho-metadata-editor/pull/194
12. https://github.com/pentaho/pentaho-metadata-editor-ee/pull/87
13. https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/798
14. https://github.com/pentaho/pentaho-reporting/pull/1351
15. https://github.com/pentaho/pdi-ee-plugin/pull/391
16. https://github.com/pentaho/pentaho-versionchecker/pull/25
17. https://github.com/pentaho/modeler/pull/367
18. https://github.com/pentaho/metastore/pull/67
19. https://github.com/pentaho/pdi-scheduler-plugin/pull/83
20. https://github.com/pentaho/pdi-plugins-ee/pull/219
21. https://github.com/pentaho/pentaho-analysis-ee/pull/36
22. dataflow-manager (N/A)