### PR TITLE
[PPP-4481] Use of Vulnerable Component: Components/h2-1.2.131.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,7 @@
     <kafka-clients.version>0.10.2.2</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
     <tomcat.version>8.5.51</tomcat.version>
+    <h2.version>1.4.200</h2.version>
 
     <!-- spring version -->
     <spring.version>4.3.22.RELEASE</spring.version>
@@ -745,6 +746,12 @@
         <groupId>org.eclipse.paho</groupId>
         <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
         <version>${paho.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>${h2.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Bumping version of `com.h2database:h2` to version **1.4.200** across all products.

PRs:
1. https://github.com/pentaho/maven-parent-poms/pull/245 (this)
2. https://github.com/pentaho/data-access/pull/1096
3. https://github.com/pentaho/pentaho-metaverse/pull/630
4. https://github.com/pentaho/pentaho-data-refinery/pull/131

**Please hold merging until all PRs are pushed and reviewed.**