### PR TITLE
[SP-5921] Backport of PDI-19103 - "java.lang.IllegalArgumentException…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <commons-compress.version>1.20</commons-compress.version>
     <commons-fileupload.version>1.4</commons-fileupload.version>
     <commons-vfs2.version>2.3</commons-vfs2.version>
-    <commons-codec.version>1.14</commons-codec.version>
+    <commons-codec.version>1.15</commons-codec.version>
     <aws-java-sdk.version>1.11.516</aws-java-sdk.version>
     <jetty.version>9.4.18.v20190429</jetty.version>
     <httpclient.version>4.5.9</httpclient.version>


### PR DESCRIPTION
…: Last encoded character (before the paddings if any)" after upgrading Pentaho Spoon to 8.3.0.16 and higher (9.1 Suite)

cherry-pick of 5dc36a976e6a2cc3dc1df236f21a1a331086bfb0 from PR https://github.com/pentaho/maven-parent-poms/pull/265

original issue had related PR's, because there were specific versions of commons-code being set in the related repos. 
In 9.1 that is not the case. Only parent pom needs to change. 

@moraesvc @bcostahitachivantara @smmribeiro 