### PR TITLE
[SP-5920] Backport of PDI-19103 - "java.lang.IllegalArgumentException…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <jackrabbit.version>2.16.5</jackrabbit.version>
     <commons-compress.version>1.20</commons-compress.version>
     <commons-fileupload.version>1.4</commons-fileupload.version>
-    <commons-codec.version>1.14</commons-codec.version>
+    <commons-codec.version>1.15</commons-codec.version>
     <aws-java-sdk.version>1.11.516</aws-java-sdk.version>
     <tomcat.version>8.5.51</tomcat.version>
 


### PR DESCRIPTION
…: Last encoded character (before the paddings if any)" after upgrading Pentaho Spoon to 8.3.0.16 and higher (8.3 Suite)

cherry-pick of 5dc36a976e6a2cc3dc1df236f21a1a331086bfb0 from PR https://github.com/pentaho/maven-parent-poms/pull/265

original issue had related PR's, because there were specific versions of commons-code being set in the related repos. 
In 8.3 that is not the case. Only parent pom needs to change. 

@moraesvc @bcostahitachivantara @smmribeiro 