### PR TITLE
[BACKLOG-35000] Adding _HV Security Web library_ version and dependency management info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,7 @@
     <grpc.version>1.27.0</grpc.version>
     <!-- endregion -->
 
+    <hv-security-web.version>0.5.0</hv-security-web.version>
   </properties>
 
   <dependencyManagement>
@@ -1081,6 +1082,33 @@
       </dependency>
       <!-- endregion -->
 
+      <!-- region HV Web Security -->
+      <dependency>
+        <groupId>com.hitachivantara.security.web</groupId>
+        <artifactId>security-web-server-api</artifactId>
+        <version>${hv-security-web.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hitachivantara.security.web</groupId>
+        <artifactId>security-web-server-model-impl</artifactId>
+        <version>${hv-security-web.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hitachivantara.security.web</groupId>
+        <artifactId>security-web-server-service-impl</artifactId>
+        <version>${hv-security-web.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hitachivantara.security.web</groupId>
+        <artifactId>csrf-token-service-client-java-jax-rs-v1</artifactId>
+        <version>${hv-security-web.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hitachivantara.security.web</groupId>
+        <artifactId>csrf-token-service-client-java-jax-rs-v2</artifactId>
+        <version>${hv-security-web.version}</version>
+      </dependency>
+      <!-- endregion HV Web Security -->
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Previous code review PR: https://github.com/pentaho/maven-parent-poms/pull/280.

Part of the changeset described in https://github.com/pentaho/security-web/pull/4#issuecomment-888511840.