### PR TITLE
[BACKLOG-35298] Upgrade security-web dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
     <grpc.version>1.27.0</grpc.version>
     <!-- endregion -->
 
-    <hv-security-web.version>0.5.1</hv-security-web.version>
+    <hv-security-web.version>0.6.0</hv-security-web.version>
     <snowflake-jdbc.version>3.6.28</snowflake-jdbc.version>
   </properties>
 


### PR DESCRIPTION
- Dependency has added support for the CSRF token parameter to be specified in the body, as part of, e.g. a POST request

Depends on https://github.com/pentaho/security-web/pull/10.

@bennychow, @ddiroma please review and merge.