### PR TITLE
[BACKLOG-35287] New version of simple-jndi compatible with both jdk 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
     <tomcat.version>9.0.50</tomcat.version>
     <bcprov-jdk14.version>1.65</bcprov-jdk14.version>
     <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
-    <simple-jndi.version>1.0.8</simple-jndi.version>
+    <simple-jndi.version>1.0.9</simple-jndi.version>
 
     <!-- spring version -->
     <spring.version>5.3.3</spring.version>


### PR DESCRIPTION
and 11.