### PR TITLE
[PDI-19520] PDI Welcome screen has wrong links

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
     <!-- Documentation properties -->
     <!-- parsedVersion.* properties are dynamically created by the build-helper-maven-plugin:set-doc-version-property -->
     <doc.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</doc.version>
-    <doc.base.url>https://help.pentaho.com/Documentation/${doc.version}</doc.base.url>
+    <doc.base.url>https://help.hitachivantara.com/Documentation/Pentaho/${doc.version}</doc.base.url>
     <doc.base.wiki.url>https://pentaho-community.atlassian.net/wiki</doc.base.wiki.url>
 
     <!-- SonarQube general configuration -->


### PR DESCRIPTION
The essential part for everything to work, is the addition of "/Pentaho" to the URL, because "help.pentaho.com" redirects to "help.hitachivantara.com".
The change "pentaho->hitachivantara" is normally done when the "code is touched" - and it translates into one less redirect :-)


@bcostahitachivantara @renato-s @andreramos89
@rmansoor @smaring 