### PR TITLE
[BACKLOG-35003] Bump security-web version to 0.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
     <grpc.version>1.27.0</grpc.version>
     <!-- endregion -->
 
-    <hv-security-web.version>0.9.0</hv-security-web.version>
+    <hv-security-web.version>0.10.0</hv-security-web.version>
     <snowflake-jdbc.version>3.13.10</snowflake-jdbc.version>
   </properties>
 


### PR DESCRIPTION
This PR depends on https://github.com/pentaho/security-web/pull/17.

Related PRs:
- https://github.com/pentaho/pentaho-platform/pull/5075
- https://github.com/pentaho/pentaho-platform-ee/pull/1526
- https://github.com/pentaho/data-access/pull/1140
- https://github.com/pentaho/pentaho-analyzer/pull/2238
- https://github.com/pentaho/pentaho-platform-plugin-dashboards/pull/536