### PR TITLE
[BACKLOG-35980] Change security-web version to 0.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
     <grpc.version>1.27.0</grpc.version>
     <!-- endregion -->
 
-    <hv-security-web.version>0.10.0</hv-security-web.version>
+    <hv-security-web.version>0.11.0</hv-security-web.version>
     <snowflake-jdbc.version>3.13.10</snowflake-jdbc.version>
     <commons-io.version>2.11.0</commons-io.version>
   </properties>


### PR DESCRIPTION
Depends on https://github.com/pentaho/security-web/pull/19.

PR set:
- https://github.com/pentaho/pentaho-platform/pull/5104
- https://github.com/pentaho/pentaho-platform-ee/pull/1532