### PR TITLE
[BACKLOG-36442] upgrade jacoco-maven-plugin:0.8.1 -> 0.8.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 
     <derby.version>10.14.2.0</derby.version>
 
-    <jacoco-maven-plugin.version>0.8.1</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>


### PR DESCRIPTION
- version 0.8.2+ fully supports java 11.