### PR TITLE
[SP-6319] - Backport of PPP-3713 - Beanshell version we're using is vulnerable to serialization exploit - CVE-2016-2510 (9.3 Suite)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@
     <xml-apis.version>1.4.01</xml-apis.version>
 
     <enunciate-jersey-rt.version>1.27</enunciate-jersey-rt.version>
+    <beanshell.version>2.1.1</beanshell.version>
 
     <!-- jdk version -->
     <!-- build for Java 8 compatibility for 9.3; to be updated to Java 11 in the next release -->


### PR DESCRIPTION
@andreramos89 
@bcostahitachivantara 
@smmribeiro 

Original PR: https://github.com/pentaho/maven-parent-poms/pull/402