### PR TITLE
[BACKLOG-37531] Bouncycastle release/version mismatch causing problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,8 +181,10 @@
     <paho.version>1.2.2</paho.version>
     <tomcat.version>9.0.70</tomcat.version>
     <h2.version>2.1.210</h2.version>
+    <!-- jdk14 and jdk15on versions not to be used; supports older third-party pom files in build -->
     <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
     <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
+    <bcprov-jdk15to18.version>1.72</bcprov-jdk15to18.version>
     <simple-jndi.version>1.0.10</simple-jndi.version>
     <batik.version>1.16</batik.version>
 


### PR DESCRIPTION
for karaf ssh service (and presumably anything else in karaf reliant on them).  Standardizing on the jdk15to18 packages since these still work on JDK1.8 (they are not multiversion jars).