### PR TITLE
[BACKLOG-38778] Upgrade "com.github.eirslett:frontend-maven-plugin" t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <maven-dependency-plugin.version>3.1.0</maven-dependency-plugin.version>
     <build-helper-maven-plugin.version>3.1.0-pentaho</build-helper-maven-plugin.version>
     <requirejs-maven-plugin.version>2.0.4</requirejs-maven-plugin.version>
-    <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
+    <frontend-maven-plugin.version>1.14.0</frontend-maven-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <iterator-maven-plugin.version>0.5.1</iterator-maven-plugin.version>
     <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>


### PR DESCRIPTION
…o address CVE-2021-26291

latest version is v1.14.0 https://mvnrepository.com/artifact/com.github.eirslett/frontend-maven-plugin
see https://hv-eng.atlassian.net/browse/BACKLOG-38778 for more details