### PR TITLE
[SP-6440] Add commons-lang3 version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
     <commons-compress.version>1.20</commons-compress.version>
     <commons-fileupload.version>1.5</commons-fileupload.version>
     <commons-vfs2.version>2.7.0</commons-vfs2.version>
+    <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-text.version>1.10.0</commons-text.version>
     <aws-java-sdk.version>1.11.516</aws-java-sdk.version>


### PR DESCRIPTION
While not on the original code for [PPP-4751](https://jira.pentaho.com/browse/PPP-4751), this commons-lang3 version property is necessary for it!
As this property was not yet introduced on 9.3 code line (was introduced on master with [maven-parent-poms#435](https://github.com/pentaho/maven-parent-poms/pull/435), but [PDI-18433](https://jira.pentaho.com/browse/PDI-18433) was not selected to backport).

@bcostahitachivantara @renato-s @andreramos89 

[PPP-4751]: https://hv-eng.atlassian.net/browse/PPP-4751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PDI-18433]: https://hv-eng.atlassian.net/browse/PDI-18433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ