### PR TITLE
[FIX] Upgrade jacoco-maven-plugin as in BACKLOG-36442

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 
     <derby.version>10.14.2.0</derby.version>
 
-    <jacoco-maven-plugin.version>0.8.1</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>


### PR DESCRIPTION
Jacoco 0.8.1 does not work well with Java 11+

@cardosov @renato-s @andreramos89 