### PR TITLE
[BACKLOG-40255] Need to back off on the maven-bundle-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <sonar-maven-plugin.version>3.5.0.1254</sonar-maven-plugin.version>
     <license-helper-maven-plugin.version>1.27</license-helper-maven-plugin.version>
     <maven-war-plugin.version>3.2.0</maven-war-plugin.version>
-    <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
+    <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
     <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
 
     <karaf-maven-plugin.version>4.2.15</karaf-maven-plugin.version>


### PR DESCRIPTION
because it is pulling java.* dependencies into bundles and our version of karaf can't work with that.