### PR TITLE
[PPP-4899] Vulnerable Component: commons-io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
     <felix.http.api.version>3.0.0</felix.http.api.version>
     <felix.http.proxy.version>3.0.6</felix.http.proxy.version>
-    <felix.http.bridge.version>4.0.6</felix.http.bridge.version>
+    <felix.http.bridge.version>4.2.18</felix.http.bridge.version>
 
     <aries.blueprint.api.version>1.0.1</aries.blueprint.api.version>
     <aries.blueprint.core.version>1.10.2</aries.blueprint.core.version>


### PR DESCRIPTION
Jira: https://hv-eng.atlassian.net/browse/PPP-4899

- Update Apache Felix HTTP Bridge version to latest minor version, containing commons-io 2.15.0, which is 2.7+, addressing CVE-2021-29425

Related PRs:
https://github.com/pentaho/pentaho-kettle/pull/9525
https://github.com/pentaho/pentaho-reporting/pull/1678