### PR TITLE
[BACKLOG-41915] -PRD-osgi fails to start with NoCLassDefFoundError in Ubuntu and MacOS environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <!-- VERSIONS -->
     <slf4j.version>1.7.12</slf4j.version>
     <logback.version>1.2.10</logback.version>
-    <log4j.version>2.23.1</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <commons-logging.version>1.2</commons-logging.version>
     <postgresql.version>42.5.6</postgresql.version>
     <ini4j.version>0.5.4</ini4j.version>


### PR DESCRIPTION
[BACKLOG-41915] -PRD-osgi fails to start with NoCLassDefFoundError in Ubuntu and MacOS environment

[BACKLOG-41915]: https://hv-eng.atlassian.net/browse/BACKLOG-41915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ