### PR TITLE
[BACKLOG-41283]-Upgrading Pentaho kettle from Java EE 9 to Jakarta EE 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
     <jakarta.activation.version>2.1.3</jakarta.activation.version>
     <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
     <jaxb-impl.version>2.3.3</jaxb-impl.version>
-    <jakarta.xml.ws-api.version>2.3.3</jakarta.xml.ws-api.version>
+    <jakarta.xml.ws-api.version>4.0.0</jakarta.xml.ws-api.version>
 
     <!-- GWT Java 11 compatibility -->
     <gwt.version>2.10.0</gwt.version>


### PR DESCRIPTION
[BACKLOG-41283]-Upgrading Pentaho kettle from Java EE 9 to Jakarta EE 10

[BACKLOG-41283]: https://hv-eng.atlassian.net/browse/BACKLOG-41283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ