### PR TITLE
[BACKLOG-42810]-Upgrading jackson.jaxrs to jackson.jakarta.rs to support Jakarta functionality as part of tomcat upgradation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -664,13 +664,13 @@
         <version>${fasterxml-jackson-databind.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+        <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         <version>${fasterxml-jackson.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jaxrs-base</artifactId>
+        <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+        <artifactId>jackson-jakarta-rs-base</artifactId>
         <version>${fasterxml-jackson.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
[BACKLOG-42810]-Upgrading jackson.jaxrs to jackson.jakarta.rs to support Jakarta functionality as part of tomcat upgradation.

[BACKLOG-42810]: https://hv-eng.atlassian.net/browse/BACKLOG-42810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ