### PR TITLE
[BACKLOG-42885]-Upgrading Jetty version from 11.0.14 to 12.0.15 to support Jakarta EE 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,8 +201,8 @@
     <commons-text.version>1.10.0</commons-text.version>
     <commons-net.version>3.9.0</commons-net.version>
     <aws-java-sdk.version>1.12.759</aws-java-sdk.version>
-    <jetty.version>11.0.14</jetty.version>
-    <jetty-server.version>11.0.14</jetty-server.version>
+    <jetty.version>12.0.15</jetty.version>
+    <jetty-server.version>12.0.15</jetty-server.version>
     <httpclient.version>4.5.14</httpclient.version>
     <httpcore.version>4.4.11</httpcore.version>
     <kafka-clients.version>3.4.0</kafka-clients.version>
@@ -456,8 +456,8 @@
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlets</artifactId>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-servlets</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
@@ -476,8 +476,8 @@
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-webapp</artifactId>
+        <groupId>org.eclipse.jetty-ee10</groupId>
+        <artifactId>jetty-ee10-webapp</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
[BACKLOG-42885]-Upgrading Jetty version from 11.0.14 to 12.0.15 to support Jakarta EE 10

[BACKLOG-42885]: https://hv-eng.atlassian.net/browse/BACKLOG-42885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ