### PR TITLE
[BACKLOG-42955]-Upgrading jackson-module-jaxb-annotations to jackson-module-jakarta-xmlbind-annotations to support Jakarta EE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -670,7 +670,7 @@
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-jaxb-annotations</artifactId>
+        <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
         <version>${fasterxml-jackson.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
[BACKLOG-42955]-Upgrading jackson-module-jaxb-annotations to jackson-module-jakarta-xmlbind-annotations to support Jakarta EE

[BACKLOG-42955]: https://hv-eng.atlassian.net/browse/BACKLOG-42955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ