### PR TITLE
[SP-6749] Backport of PPP-5480 - Upgrade "pax-web" to address Vulnerable Component: Tomcat 9.0.91 (10.2 Suite)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <aries.blueprint.api.version>1.0.1</aries.blueprint.api.version>
     <aries.blueprint.core.version>1.10.2</aries.blueprint.core.version>
 
-    <pax-web.version>8.0.27</pax-web.version>
+    <pax-web.version>8.0.30</pax-web.version>
     <pax-url-aether.version>2.6.14</pax-url-aether.version>
     <cxf.version>3.6.4</cxf.version>
 


### PR DESCRIPTION
Actual PR: https://github.com/pentaho/maven-parent-poms/pull/664