### PR TITLE
[SP-6775] Update Apache Felix HTTP Bridge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
     <felix.http.api.version>3.0.0</felix.http.api.version>
     <felix.http.proxy.version>3.0.6</felix.http.proxy.version>
-    <felix.http.bridge.version>4.0.6</felix.http.bridge.version>
+    <felix.http.bridge.version>4.2.18</felix.http.bridge.version>
 
     <aries.blueprint.api.version>1.0.1</aries.blueprint.api.version>
     <aries.blueprint.core.version>1.10.2</aries.blueprint.core.version>


### PR DESCRIPTION
- Update Apache Felix HTTP Bridge version to latest minor version, containing commons-io 2.15.0, which is 2.7+, addressing CVE-2021-29425

(cherry picked from commit 72b81732a5af9664e850853c6eb6bbc259b19226)

@pentaho/tatooine_dev 