### PR TITLE
feat: bump pax-web to 8.0.31 [PPP-5627]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <osgi.compendium.version>7.0.0</osgi.compendium.version>
 
     <karaf.version>4.4.6</karaf.version>
-    <pentaho.custom.karaf.version>4.4.6-2025.01.24</pentaho.custom.karaf.version>
+    <pentaho.custom.karaf.version>4.4.6-2025.03.14</pentaho.custom.karaf.version>
 
     <felix.http.api.version>3.0.0</felix.http.api.version>
     <felix.http.proxy.version>3.0.6</felix.http.proxy.version>
@@ -87,7 +87,6 @@
     <aries.blueprint.api.version>1.0.1</aries.blueprint.api.version>
     <aries.blueprint.core.version>1.10.2</aries.blueprint.core.version>
 
-    <pax-web.version>8.0.30</pax-web.version>
     <pax-url-aether.version>2.6.16</pax-url-aether.version>
     <cxf.version>3.6.4</cxf.version>
 
@@ -125,8 +124,15 @@
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
     <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
 
-    <karaf-maven-plugin.version>4.4.6-2025.01.24</karaf-maven-plugin.version>
-    <hitachi-karaf-maven-plugin.version>4.4.6-2025.01.24</hitachi-karaf-maven-plugin.version>
+    <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
+    <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
+    <tomcat.version>9.0.100</tomcat.version>
+    <pax-web.version>8.0.31</pax-web.version>
+    <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
+    <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
+
+    <karaf-maven-plugin.version>4.4.6-2025.03.14</karaf-maven-plugin.version>
+    <hitachi-karaf-maven-plugin.version>4.4.6-2025.03.14</hitachi-karaf-maven-plugin.version>
     <karaf-maven-plugin.enableGeneration>true</karaf-maven-plugin.enableGeneration>
     <karaf-maven-plugin.aggregateFeatures>false</karaf-maven-plugin.aggregateFeatures>
     <karaf-maven-plugin.includeTransitiveDependency>true</karaf-maven-plugin.includeTransitiveDependency>
@@ -189,7 +195,6 @@
     <httpcore.version>4.4.11</httpcore.version>
     <kafka-clients.version>3.4.0</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
-    <tomcat.version>9.0.100</tomcat.version>
     <h2.version>2.2.224</h2.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
     <!-- jdk14 and jdk15on versions not to be used; supports older third-party pom files in build -->


### PR DESCRIPTION
Added comments to ensure that when updating tomcat, pax-web is also updated.
Also updating our custom karaf to a version that uses the same pax-web.

@pentaho/tatooine_dev 