### PR TITLE
[SP-6805] Backport of PPP-5589 - Vulnerable Component: commons-io (de…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <aries.blueprint.api.version>1.0.1</aries.blueprint.api.version>
     <aries.blueprint.core.version>1.10.2</aries.blueprint.core.version>
 
-    <pax-url-aether.version>2.6.14</pax-url-aether.version>
+    <pax-url-aether.version>2.6.16</pax-url-aether.version>
     <cxf.version>3.6.4</cxf.version>
 
     <activemq.version>5.18.4</activemq.version>


### PR DESCRIPTION
…ep scan) (10.2 Suite)

[PPP-5589] [PPP-5618] Vulnerable Component: commons-io (Karaf)
- Update pax-url-aether version: 2.6.14 -> 2.6.16

(cherry picked from commit e87e8cc)

[PPP-5589]: https://hv-eng.atlassian.net/browse/PPP-5589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PPP-5618]: https://hv-eng.atlassian.net/browse/PPP-5618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ