### PR TITLE
[SP-6819] Backport of PPP-5516 - Vulnerable Component: requirejs 2.3.6 (10.2 Suite)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,19 @@
     <xmlbeans.version>5.2.0</xmlbeans.version>
     <nodejs.version>v10.0.0</nodejs.version>
     <npm.version>5.7.1</npm.version>
-    <requirejs.version>2.3.6</requirejs.version>
+    <requirejs.version>2.3.7</requirejs.version>
+
+    <!--
+      Should be updated to 3.1.0 so it includes requirejs@2.3.7. but doing so would require all projects
+      that use this dependency to update their node and karma versions, to support ES2015+ syntax
+      introduced in the new version r.js file.
+
+      It is safe to keep the current version for now, as all projects only use r.js (and not require.js) for optimization.
+      The only exception is pentaho-platform-common-ui, that includes require.js in the final build,
+      so we are overriding this version there.
+    -->
     <prantlf.requirejs.version>3.0.2</prantlf.requirejs.version>
+
     <bootstrap.version>3.4.1</bootstrap.version>
     <dojo.version>1.17.3</dojo.version>
 


### PR DESCRIPTION
@pentaho/millenniumfalcon please review

Related PRs:
 - https://github.com/pentaho/maven-parent-poms-ee/pull/103
 - https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1842
 - https://github.com/pentaho/pentaho-analyzer/pull/2702
 - https://github.com/pentaho/pentaho-platform-plugin-geo/pull/426
 - https://github.com/pentaho/pentaho-platform-plugin-dashboards/pull/604
 - https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/896
 - https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/1137
 - https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/327
 - https://github.com/pentaho/pentaho-det/pull/1392
 - https://github.com/pentaho/pentaho-det-ee/pull/701