### PR TITLE
[BACKLOG-43874]-Fix JDK21 test pipeline(test1) build failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
 
-    <karaf-maven-plugin.version>4.4.6-2025.04.04</karaf-maven-plugin.version>
+    <karaf-maven-plugin.version>4.4.7</karaf-maven-plugin.version>
     <hitachi-karaf-maven-plugin.version>4.4.6-2025.04.04</hitachi-karaf-maven-plugin.version>
     <karaf-maven-plugin.enableGeneration>true</karaf-maven-plugin.enableGeneration>
     <karaf-maven-plugin.aggregateFeatures>false</karaf-maven-plugin.aggregateFeatures>


### PR DESCRIPTION
[BACKLOG-43874]-Fix JDK21 test pipeline(test1) build failures

[BACKLOG-43874]: https://hv-eng.atlassian.net/browse/BACKLOG-43874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ