### PR TITLE
[BACKLOG-43938]-Fixing test1 pipeline test failures running on JDK21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <commons-logging.version>1.2</commons-logging.version>
     <postgresql.version>42.5.6</postgresql.version>
     <ini4j.version>0.5.4</ini4j.version>
+    <byte-buddy.version>1.17.5</byte-buddy.version>
 
     <osgi.core.version>8.0.0</osgi.core.version>
     <osgi.compendium.version>7.0.0</osgi.compendium.version>


### PR DESCRIPTION
[BACKLOG-43938]-Fixing test1 pipeline test failures running on JDK21