### PR TITLE
build: bump tomcat version 9.0.100 > 9.0.105

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
-    <tomcat.version>9.0.100</tomcat.version>
+    <tomcat.version>9.0.105</tomcat.version>
     <pax-web.version>8.0.31</pax-web.version>
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->


### PR DESCRIPTION
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L129-R129): Updated `<tomcat.version>` from `9.0.100` to `9.0.105` for compatibility with `pax-web` components and the custom Hitachi Karaf.