### PR TITLE
feat[PPP-5649]: use the most recent versions of httpclient5 and httpcore5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,9 +203,9 @@
     <jetty.version>9.4.57.v20241219</jetty.version>
     <jetty-server.version>9.4.57.v20241219</jetty-server.version>
     <httpclient.version>4.5.14</httpclient.version>
-    <httpclient5.version>5.4.1</httpclient5.version>
+    <httpclient5.version>5.4.4</httpclient5.version>
     <httpcore.version>4.4.11</httpcore.version>
-    <httpcore5.version>5.3.3</httpcore5.version>
+    <httpcore5.version>5.3.4</httpcore5.version>
     <kafka-clients.version>3.4.0</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>


### PR DESCRIPTION
I've previously used httpclient5:5.4.1 and httpcore5:5.3.3 as they were the versions that VFS2:2.10.0 used. As httpclient5:5.4.1 has a vulnerability, this PR is to bump both versions to the most recent ones (5.4.4 and 5.3.4, respectively).
