### PR TITLE
[BACKLOG-45016]-Upgrading Tomcat from 10.1.39 to 10.1.43

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
-    <tomcat.version>10.1.39</tomcat.version>
+    <tomcat.version>10.1.43</tomcat.version>
     <pax-web.version>8.0.32</pax-web.version>
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->


### PR DESCRIPTION
[BACKLOG-45016]-Upgrading Tomcat from 10.1.39 to 10.1.43

[BACKLOG-45016]: https://hv-eng.atlassian.net/browse/BACKLOG-45016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ