### PR TITLE
build[PPP-5769]: Update commons-fileupload version to 2.0.0-M4 and commons-fileupload-osgi to 1.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ release.properties
 pom.xml.releaseBackup
 *.iml
 .idea
+.vscode
 bin
 *.class
 *.jar

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
     <jackrabbit.version>2.21.19</jackrabbit.version>
     <oak-jackrabbit.version>1.48.0</oak-jackrabbit.version>
     <commons-compress.version>1.26.2</commons-compress.version>
-    <commons-fileupload.version>2.0.0-M2</commons-fileupload.version>
+    <commons-fileupload.version>2.0.0-M4</commons-fileupload.version>
     <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
     <commons-pool2.version>2.11.1</commons-pool2.version>
     <commons-vfs2.version>2.10.0</commons-vfs2.version>
@@ -288,7 +288,7 @@
     <jakarta.activation.version>2.1.3</jakarta.activation.version>
     <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
     <jakarta.xml.bind-osgi.version>2.3.3</jakarta.xml.bind-osgi.version>
-    <commons-fileupload-osgi.version>1.5</commons-fileupload-osgi.version>
+    <commons-fileupload-osgi.version>1.6.0</commons-fileupload-osgi.version>
     <jaxb-api-osgi.version>2.3.3</jaxb-api-osgi.version>
     <jakarta.activation-osgi.version>1.2.1</jakarta.activation-osgi.version>
     <jakarta.transaction-api-osgi.version>1.3.3</jakarta.transaction-api-osgi.version>
@@ -805,6 +805,11 @@
         <version>${commons-compress.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>commons-fileupload</groupId>
+        <artifactId>commons-fileupload</artifactId>
+        <version>${commons-fileupload-osgi.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-fileupload2-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <osgi.compendium.version>7.0.0</osgi.compendium.version>
 
     <karaf.version>4.4.6</karaf.version>
-    <pentaho.custom.karaf.version>4.4.6-2025.07.01</pentaho.custom.karaf.version>
+    <pentaho.custom.karaf.version>4.4.6-2025.08.05</pentaho.custom.karaf.version>
 
     <felix.http.api.version>3.0.0</felix.http.api.version>
     <felix.http.proxy.version>4.0.0</felix.http.proxy.version>


### PR DESCRIPTION
This pull request updates dependency versions related to Apache Commons FileUpload in the `pom.xml`. These changes are required, as stated in PPP-5769, to address CVE-2025-48976.

Also added `.vscode` to `.gitignore`, to ignore VS Code configuration files. **Merge this commit separately.**

Dependency version updates:

* Updated `commons-fileupload.version` from `2.0.0-M2` to `2.0.0-M4` to use a more recent milestone release.
* Updated `commons-fileupload-osgi.version` from `1.5` to `1.6.0` for the OSGi-compatible version.
* Updated `pentaho.custom.karaf.version` from `4.4.6-2025.07.01` to `4.4.6-2025.08.05`.

Dependency management improvements:

* Added a new dependency management entry with `commons-fileupload`, using the `${commons-fileupload-osgi.version}` property.

- [x] **⚠️ Merge only after DEVO-12740 is closed, to ensure that `pentaho.custom.karaf.` version `4.4.6-2025.08.05` exists**