### PR TITLE
build[PPP-5751]: update GWT version to 2.12.2 and adjust groupId for GWT dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,6 @@
     <jakarta.servlet.jsp.jstl-api.version>3.0.2</jakarta.servlet.jsp.jstl-api.version>
     <jakarta.servlet.jsp.jstl.version>3.0.1</jakarta.servlet.jsp.jstl.version>
     <antlr4-runtime.version>4.13.0</antlr4-runtime.version>
-    <gwt-servlet-jakarta.version>2.12.2</gwt-servlet-jakarta.version>
     <webservices.version>4.0.4</webservices.version>
     <jaxb-runtime.version>4.0.5</jaxb-runtime.version>
     <fasterxml-jackson.version>2.17.2</fasterxml-jackson.version>
@@ -304,8 +303,9 @@
     <cache-api.version>1.1.1</cache-api.version>
     <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
 
-    <!-- GWT Java 11 compatibility -->
-    <gwt.version>2.10.0</gwt.version>
+    <!-- GWT dependencies -->
+    <gwt.version>2.12.2</gwt.version>
+    <gwt-maven-plugin.version>2.10.0</gwt-maven-plugin.version>
     <gwt-incubator.version>2.1.0</gwt-incubator.version>
     <gwt-dnd.version>3.3.4</gwt-dnd.version>
     <gwtmockito.version>1.1.9</gwtmockito.version>
@@ -1334,24 +1334,24 @@
       </dependency>
       <!-- endregion HV Web Security -->
 
-      <!-- GWT Java 11+ compatibility -->
+      <!-- GWT dependencies -->
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-user</artifactId>
         <version>${gwt.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-dev</artifactId>
         <version>${gwt.version}</version>
       </dependency>
       <dependency>
         <groupId>org.gwtproject</groupId>
         <artifactId>gwt-servlet-jakarta</artifactId>
-        <version>${gwt-servlet-jakarta.version}</version>
+        <version>${gwt.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-codeserver</artifactId>
         <version>${gwt.version}</version>
       </dependency>
@@ -1386,7 +1386,8 @@
         <artifactId>GWT-FX</artifactId>
         <version>${GWT-FX.version}</version>
       </dependency>
-      <!-- end GWT Java 11+ compatibility -->
+      <!-- end GWT dependencies -->
+
       <dependency>
         <groupId>com.rometools</groupId>
         <artifactId>rome</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1785,6 +1785,24 @@
             <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
           </configuration>
         </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>gwt-maven-plugin</artifactId>
+          <version>${gwt-maven-plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.gwtproject</groupId>
+              <artifactId>gwt-dev</artifactId>
+              <version>${gwt.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.gwtproject</groupId>
+              <artifactId>gwt-user</artifactId>
+              <version>${gwt.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
This pull request updates the GWT (Google Web Toolkit) dependencies in the `pom.xml` file to use the latest versions and switches from the legacy `com.google.gwt` group to the newer `org.gwtproject` group. It also streamlines the GWT version management by removing a separate version property for `gwt-servlet-jakarta` and updating related comments for clarity.

**GWT Dependency Updates:**

* Updated the `gwt.version` property to `2.12.2` and added a new property for `gwt-maven-plugin.version`, ensuring all GWT dependencies use the latest compatible versions.
* Changed all GWT dependencies from the `com.google.gwt` group to the `org.gwtproject` group, since versions post-2.10.0 are only available on that groupId.

**Version Management Improvements:**

* Removed the separate `gwt-servlet-jakarta.version` property and unified its versioning with the main `gwt.version` property. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L209) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L1337-R1354)