### PR TITLE
fix[PPP-5888]: bump netty version to 4.1.124.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -459,7 +459,7 @@
     <mina-core.version>2.2.4</mina-core.version>
     <saxon.version>9.1.0.8</saxon.version>
     <saxon-he.version>12.7</saxon-he.version>
-    <netty.version>4.1.118.Final</netty.version>
+    <netty.version>4.1.124.Final</netty.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
To avoid vulnerable version of `netty-codec-http2` jar