### PR TITLE
Revert "feat[PPP-5739]: replace ini4j with commons-configuration2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <log4j-slf4j2.version>2.24.1</log4j-slf4j2.version>
     <commons-logging.version>1.3.5</commons-logging.version>
     <postgresql.version>42.5.6</postgresql.version>
+    <ini4j.version>0.5.4</ini4j.version>
 
     <osgi.core.version>8.0.0</osgi.core.version>
     <osgi.compendium.version>7.0.0</osgi.compendium.version>
@@ -461,7 +462,6 @@
     <netty.version>4.1.125.Final</netty.version>
     <xmlresolver.version>6.0.17</xmlresolver.version>
     <xmlunit.version>1.6</xmlunit.version>
-    <commons-configuration2.version>2.10.1</commons-configuration2.version>
   </properties>
 
   <dependencyManagement>
@@ -1459,11 +1459,6 @@
         <groupId>xmlunit</groupId>
         <artifactId>xmlunit</artifactId>
         <version>${xmlunit.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-configuration2</artifactId>
-        <version>${commons-configuration2.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Reverts pentaho/maven-parent-poms#759

Need to revert as Wingman was unable to conclude the other PRs that are related with the change.

