### PR TITLE
fix[SP-6939]: bump netty to 4.1.125.Final and aws-java-sdk  to 1.12.791

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
     <commons-codec.version>1.15</commons-codec.version>
     <commons-text.version>1.10.0</commons-text.version>
     <commons-net.version>3.9.0</commons-net.version>
-    <aws-java-sdk.version>1.12.788</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.791</aws-java-sdk.version>
     <jetty.version>9.4.57.v20241219</jetty.version>
     <jetty-server.version>9.4.57.v20241219</jetty-server.version>
     <httpclient.version>4.5.14</httpclient.version>
@@ -413,7 +413,7 @@
     <mina-core.version>2.2.4</mina-core.version>
     <amqp.version>5.22.0</amqp.version>
     <jettison.version>1.5.4</jettison.version>
-    <netty.version>4.1.124.Final</netty.version>
+    <netty.version>4.1.125.Final</netty.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Original commit: https://github.com/pentaho/maven-parent-poms/pull/777