### PR TITLE
build[PDI-20311]: add apache-sshd dependencies and version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -459,6 +459,7 @@
     <xmlresolver.version>6.0.17</xmlresolver.version>
     <xmlunit.version>1.6</xmlunit.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
+    <apache-sshd.version>2.16.0</apache-sshd.version>
   </properties>
 
   <dependencyManagement>
@@ -1461,6 +1462,22 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-configuration2</artifactId>
         <version>${commons-configuration2.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-core</artifactId>
+        <version>${apache-sshd.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-sftp</artifactId>
+        <version>${apache-sshd.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-scp</artifactId>
+        <version>${apache-sshd.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This pull request adds support for Apache SSHD libraries to the project by introducing new dependencies and a version property in the `pom.xml` file. These changes set up the project to use SSH, SFTP, and SCP features, likely for secure file transfer or remote command execution.

Dependency management updates:

* Added a new property `apache-sshd.version` (set to 2.16.0) to manage the version of Apache SSHD dependencies.
* Added the following dependencies under dependency management:
  * `org.apache.sshd:sshd-core`
  * `org.apache.sshd:sshd-sftp`
  * `org.apache.sshd:sshd-scp`
  All use the new `${apache-sshd.version}` property for versioning.