### PR TITLE
build[PPP-6392]: Update ActiveMQ version to 5.19.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <pax-url-aether.version>2.6.16</pax-url-aether.version>
     <cxf.version>3.6.8</cxf.version>
 
-    <activemq.version>5.19.2</activemq.version>
+    <activemq.version>5.19.5</activemq.version>
     <byte-buddy.version>1.17.6</byte-buddy.version>
     <maven-filtering.version>3.3.1</maven-filtering.version>
     <javassist.version>3.30.2-GA</javassist.version>


### PR DESCRIPTION
Bump ActiveMQ version from `5.19.2` to `5.19.5`, in order to address `CVE-2026-34197`.

@pentaho/tatooine_dev 