### PR TITLE
fix[SP-7182]: bump tomcat from 9.0.112 to 9.0.117

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
 
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
-    <tomcat.version>10.1.53</tomcat.version>
+    <tomcat.version>9.0.117</tomcat.version>
     <pax-web.version>8.0.32</pax-web.version>
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
 
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
-    <tomcat.version>9.0.112</tomcat.version>
+    <tomcat.version>10.1.53</tomcat.version>
     <pax-web.version>8.0.32</pax-web.version>
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->


### PR DESCRIPTION
original PRs: https://github.com/pentaho/maven-parent-poms/pull/829, https://github.com/pentaho/maven-parent-poms/pull/833
@pentaho/tatooine_dev 