### PR TITLE
build[SP-7221]: Update ActiveMQ version to 5.19.5 (#835)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <pax-url-aether.version>2.6.16</pax-url-aether.version>
     <cxf.version>3.6.8</cxf.version>
 
-    <activemq.version>5.18.7</activemq.version>
+    <activemq.version>5.19.5</activemq.version>
     <byte-buddy.version>1.17.6</byte-buddy.version>
     <maven-filtering.version>3.3.1</maven-filtering.version>
     <javassist.version>3.30.2-GA</javassist.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information

**SP Issue:** [SP-7221 - CVE-2026-34197 Security Backport](https://hv-eng.atlassian.net/browse/SP-7221)
**Base Case:** [PPP-6392 - CVE-2026-34197 Security Fix](https://hv-eng.atlassian.net/browse/PPP-6392)
**Original Master PR:** [pentaho/maven-parent-poms#835](https://github.com/pentaho/maven-parent-poms/pull/835)

## Changes
- Updated Apache ActiveMQ from 5.19.2 to 5.19.5 (security fix for CVE-2026-34197)
- File: pom.xml
- Commit: 7e39dc1a5d9dce72b192daf5108e58e0758ba3af

## Conflict Resolution
- Branch 11.0 had ActiveMQ 5.18.7 for compatibility
- Applied Option A: Updated to 5.19.5 (exact same fix as master)
- Rationale: Ensures uniform security coverage across all maintenance branches

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
- **Code Freeze Status:** Detected (SP2026 - 11.0.0.2), but backport only to maintenance branch per policy