### PR TITLE
chore[SP-7186]: bump netty to 4.1.131.Final (#822)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -459,7 +459,7 @@
     <amqp.version>5.22.0</amqp.version>
     <mina-core.version>2.2.4</mina-core.version>
     <saxon-he.version>12.7</saxon-he.version>
-    <netty.version>4.1.125.Final</netty.version>
+    <netty.version>4.1.131.Final</netty.version>
     <grpc-netty.version>1.78.0</grpc-netty.version>
     <xmlresolver.version>6.0.17</xmlresolver.version>
     <xmlunit.version>1.6</xmlunit.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
**SP Issue:** [SP-7186 - Backport of PPP-6270 - (11.0 Suite) CVE-2025-67735 | Vulnerable component io.netty:netty-codec-http detected in Pentaho](https://hv-eng.atlassian.net/browse/SP-7186)
**Base Case:** [PPP-6270 - CVE-2025-67735 | Vulnerable component io.netty:netty-codec-http detected in Pentaho](https://hv-eng.atlassian.net/browse/PPP-6270)
**Original Master PR:** [pentaho/maven-parent-poms#822](https://github.com/pentaho/maven-parent-poms/pull/822)

## Changes
- bumped netty version to 4.1.131.Final in parent pom for CVE-2025-67735 remediation
- Commit: fc34ace350f85d0adc196f45f75cf73f3d8e8408

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
- **Code Freeze Status:** Detected (SP2026 - 11.0 (11.0.0.2)), but backport only to maintenance branch per policy