### PR TITLE
chore[SP-7118]: add datatables version to parent pom and update it to 1.13.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@
     <json-smart.version>2.5.2</json-smart.version>
     <json-simple.version>1.1.1</json-simple.version>
     <batik.version>1.17</batik.version>
+    <datatables.version>1.13.5</datatables.version>
 
     <!-- spring version -->
     <spring.version>5.3.39</spring.version>
@@ -925,6 +926,11 @@
         <groupId>org.webjars.npm</groupId>
         <artifactId>fancyapps__fancybox</artifactId>
         <version>${fancyapps__fancybox.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars</groupId>
+        <artifactId>datatables</artifactId>
+        <version>${datatables.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7118 - Backport of PPP-5037 - Vulnerable Component: DataTables (10.2 Suite)](https://hv-eng.atlassian.net/browse/SP-7118)
- **Base Case:** [PPP-5037 - Vulnerable Component: DataTables](https://hv-eng.atlassian.net/browse/PPP-5037)
- **Original Master PR:** https://github.com/pentaho/maven-parent-poms/pull/814

## Changes
- Added datatables version property to parent pom
- Updated datatables to 1.13.5 (removes vulnerable bundled version)
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required.

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
