### PR TITLE
chore[SP-7120]: centralize grpc-netty-shaded version and update it to 1.78.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,7 @@
     <netty.version>4.1.131.Final</netty.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
     <saxon-he.version>12.7</saxon-he.version>
+    <grpc-netty.version>1.78.0</grpc-netty.version>
     <xmlresolver.version>6.0.17</xmlresolver.version>
     <xmlunit.version>1.6</xmlunit.version>
     <apache-sshd.version>2.16.0</apache-sshd.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7120 - Backport of PPP-6180 - (10.2 Suite) CVE-2025-55163 | pdia-master has a security violation in gav://io.grpc:grpc-netty-shaded:1.67.1](https://hv-eng.atlassian.net/browse/SP-7120)
- **Base Case:** [PPP-6180 - Backport of PPP-6180 - (10.2 Suite) CVE-2025-55163 | pdia-master has a security violation in gav://io.grpc:grpc-netty-shaded:1.67.1](https://hv-eng.atlassian.net/browse/PPP-6180)
- **Original Master PR:** https://github.com/pentaho/maven-parent-poms/pull/816

## Changes
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/816
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
