### PR TITLE
build[PPP-6390][PPP-6391]: Remove unused bouncycastle version properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,10 +246,6 @@
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
-    <!-- jdk14 and jdk15on versions not to be used; supports older third-party pom files in build -->
-    <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
-    <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
-    <bcprov-jdk15to18.version>1.84</bcprov-jdk15to18.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <simple-jndi.version>1.0.13</simple-jndi.version>
     <json-smart.version>2.5.2</json-smart.version>


### PR DESCRIPTION
After the following PRs are merged, these properties will no longer used anywhere in pentaho org projects, so they can be removed:

- https://github.com/pentaho/big-data-plugin/pull/2969 
- https://github.com/pentaho/pentaho-big-data-ee/pull/805 
- https://github.com/pentaho/pdi-plugins-ee/pull/2473 