### PR TITLE
build[SP-7278]: bump bcprov-jdk15to18 to 1.84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <osgi.compendium.version>7.0.0</osgi.compendium.version>
 
     <karaf.version>4.4.6</karaf.version>
-    <pentaho.custom.karaf.version>4.4.6-2025.11.19</pentaho.custom.karaf.version>
+    <pentaho.custom.karaf.version>4.4.6-2026.05.04</pentaho.custom.karaf.version>
 
     <felix.http.api.version>3.0.0</felix.http.api.version>
     <felix.http.proxy.version>4.0.0</felix.http.proxy.version>
@@ -133,8 +133,8 @@
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
 
-    <karaf-maven-plugin.version>4.4.6-2025.11.19</karaf-maven-plugin.version>
-    <hitachi-karaf-maven-plugin.version>4.4.6-2025.11.19</hitachi-karaf-maven-plugin.version>
+    <karaf-maven-plugin.version>4.4.6-2026.05.04</karaf-maven-plugin.version>
+    <hitachi-karaf-maven-plugin.version>4.4.6-2026.05.04</hitachi-karaf-maven-plugin.version>
     <karaf-maven-plugin.enableGeneration>true</karaf-maven-plugin.enableGeneration>
     <karaf-maven-plugin.aggregateFeatures>false</karaf-maven-plugin.aggregateFeatures>
     <karaf-maven-plugin.includeTransitiveDependency>true</karaf-maven-plugin.includeTransitiveDependency>

--- a/pom.xml
+++ b/pom.xml
@@ -246,10 +246,6 @@
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
-    <!-- jdk14 and jdk15on versions not to be used; supports older third-party pom files in build -->
-    <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
-    <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
-    <bcprov-jdk15to18.version>1.84</bcprov-jdk15to18.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <simple-jndi.version>1.0.13</simple-jndi.version>
     <json-smart.version>2.5.2</json-smart.version>

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,7 @@
     <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
     <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
     <bouncycastle.version>1.84</bouncycastle.version>
+    <bcprov-jdk15to18.version>${bouncycastle.version}</bcprov-jdk15to18.version>
     <simple-jndi.version>1.0.13</simple-jndi.version>
     <json-smart.version>2.5.2</json-smart.version>
     <json-simple.version>1.1.1</json-simple.version>

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,8 @@
     <!-- jdk14 and jdk15on versions not to be used; supports older third-party pom files in build -->
     <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
     <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
-    <bcprov-jdk15to18.version>1.78.1</bcprov-jdk15to18.version>
+    <bcprov-jdk15to18.version>1.84</bcprov-jdk15to18.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
     <simple-jndi.version>1.0.13</simple-jndi.version>
     <json-smart.version>2.5.2</json-smart.version>
     <json-simple.version>1.1.1</json-simple.version>
@@ -947,6 +948,8 @@
         <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
         <version>${paho.version}</version>
       </dependency>
+
+      <!-- Bouncy Castle - support older third-party pom files in build -->
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk14</artifactId>
@@ -956,6 +959,33 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${bcprov-jdk15on.version}</version>
+      </dependency>
+
+      <!-- Bouncy Castle -->
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk15to18</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcmail-jdk15to18</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk15to18</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcutil-jdk15to18</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,9 @@
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <!-- jdk14 and jdk15on versions not to be used; supports older third-party pom files in build -->
+    <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
+    <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <simple-jndi.version>1.0.13</simple-jndi.version>
     <json-smart.version>2.5.2</json-smart.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7278 - Backport of PPP-6391 - (11.0 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/SP-7278)
- **Base Case:** [PPP-6391 - Backport of PPP-6391 - (11.0 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/PPP-6391)
- **Original Master PRs:**
  - https://github.com/pentaho/maven-parent-poms/pull/843
  - https://github.com/pentaho/maven-parent-poms/pull/846
  - https://github.com/pentaho/maven-parent-poms/pull/848
  - https://github.com/pentaho/maven-parent-poms/pull/850

## Changes
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/843
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/846
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/848
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/850
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
