### PR TITLE
build[SP-7277]: bump bcprov-jdk15to18 to 1.84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,9 @@
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <!-- jdk14 and jdk15on versions not to be used; supports older third-party pom files in build -->
+    <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
+    <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <simple-jndi.version>1.0.13</simple-jndi.version>
     <json-smart.version>2.5.2</json-smart.version>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,7 @@
     <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
     <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
     <bouncycastle.version>1.84</bouncycastle.version>
+    <bcprov-jdk15to18.version>${bouncycastle.version}</bcprov-jdk15to18.version>
     <simple-jndi.version>1.0.13</simple-jndi.version>
     <json-smart.version>2.5.2</json-smart.version>
     <json-simple.version>1.1.1</json-simple.version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <osgi.compendium.version>7.0.0</osgi.compendium.version>
 
     <karaf.version>4.4.6</karaf.version>
-    <pentaho.custom.karaf.version>4.4.6-2025.11.19</pentaho.custom.karaf.version>
+    <pentaho.custom.karaf.version>4.4.6-2026.05.04</pentaho.custom.karaf.version>
 
     <felix.http.api.version>3.0.0</felix.http.api.version>
     <felix.http.proxy.version>3.0.6</felix.http.proxy.version>
@@ -130,8 +130,8 @@
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
 
-    <karaf-maven-plugin.version>4.4.6-2025.11.19</karaf-maven-plugin.version>
-    <hitachi-karaf-maven-plugin.version>4.4.6-2025.11.19</hitachi-karaf-maven-plugin.version>
+    <karaf-maven-plugin.version>4.4.6-2026.05.04</karaf-maven-plugin.version>
+    <hitachi-karaf-maven-plugin.version>4.4.6-2026.05.04</hitachi-karaf-maven-plugin.version>
     <karaf-maven-plugin.enableGeneration>true</karaf-maven-plugin.enableGeneration>
     <karaf-maven-plugin.aggregateFeatures>false</karaf-maven-plugin.aggregateFeatures>
     <karaf-maven-plugin.includeTransitiveDependency>true</karaf-maven-plugin.includeTransitiveDependency>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,8 @@
     <!-- jdk14 and jdk15on versions not to be used; supports older third-party pom files in build -->
     <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
     <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
-    <bcprov-jdk15to18.version>1.78.1</bcprov-jdk15to18.version>
+    <bcprov-jdk15to18.version>1.84</bcprov-jdk15to18.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
     <simple-jndi.version>1.0.13</simple-jndi.version>
     <json-smart.version>2.5.2</json-smart.version>
     <json-simple.version>1.1.1</json-simple.version>
@@ -897,6 +898,8 @@
         <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
         <version>${paho.version}</version>
       </dependency>
+
+      <!-- Bouncy Castle - support older third-party pom files in build -->
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk14</artifactId>
@@ -906,6 +909,33 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${bcprov-jdk15on.version}</version>
+      </dependency>
+
+      <!-- Bouncy Castle -->
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk15to18</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcmail-jdk15to18</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk15to18</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcutil-jdk15to18</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -212,10 +212,6 @@
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>
-    <!-- jdk14 and jdk15on versions not to be used; supports older third-party pom files in build -->
-    <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
-    <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
-    <bcprov-jdk15to18.version>1.84</bcprov-jdk15to18.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <simple-jndi.version>1.0.13</simple-jndi.version>
     <json-smart.version>2.5.2</json-smart.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7277 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/SP-7277)
- **Base Case:** [PPP-6391 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/PPP-6391)
- **Original Master PRs:**
  - https://github.com/pentaho/maven-parent-poms/pull/843
  - https://github.com/pentaho/maven-parent-poms/pull/846
  - https://github.com/pentaho/maven-parent-poms/pull/848
  - https://github.com/pentaho/maven-parent-poms/pull/850

## Changes
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/843
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/846
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/848
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/850
- Commit: fc680f09aa34cad835c755d18293d62e3865a7f4
- Commit: 302257026c4a1d1fed1719df0305c84ac4693848
- Commit: e2165d53c065323d610df8a1b61104ca5ec59d9c
- Commit: 39be49bf9eace07e1abd86f676746ce10276cf04

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
