### PR TITLE
build[SP-7287]: Upgrade spring-security-web to 6.5.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
     <spring-se-jcr.version>0.9</spring-se-jcr.version>
     <spring-mock.version>2.0.8</spring-mock.version>
     <spring-osgi.version>1.2.1</spring-osgi.version>
-    <spring-security.version>6.5.9</spring-security.version>
+    <spring-security.version>6.5.10</spring-security.version>
     <spring-security-core-tests.version>2.0.5.RELEASE</spring-security-core-tests.version>
     <spring-retry.version>1.2.2.RELEASE</spring-retry.version>
     <spring-boot.version>2.4.2</spring-boot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
     <spring-se-jcr.version>0.9</spring-se-jcr.version>
     <spring-mock.version>2.0.8</spring-mock.version>
     <spring-osgi.version>1.2.1</spring-osgi.version>
-    <spring-security.version>6.4.12</spring-security.version>
+    <spring-security.version>6.5.9</spring-security.version>
     <spring-security-core-tests.version>2.0.5.RELEASE</spring-security-core-tests.version>
     <spring-retry.version>1.2.2.RELEASE</spring-retry.version>
     <spring-boot.version>2.4.2</spring-boot.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7287 - Backport of PPP-6319 - (11.0 suite) CVE-2026-22732 | pdia-master (PDI Code product) has a security violation in spring-security-web](https://hv-eng.atlassian.net/browse/SP-7287)
- **Base Case:** [PPP-6319 - CVE-2026-22732 | pdia-master (PDI Code product) has a security violation in spring-security-web](https://hv-eng.atlassian.net/browse/PPP-6319)
- **Original Master PR:** https://github.com/pentaho/maven-parent-poms/pull/832, https://github.com/pentaho/maven-parent-poms/pull/845

## Changes
- Cherry-picked PR #832 (build(PPP-6319): Upgrade spring-security-web) — commit 7150e3b.
- Cherry-picked PR #845 (build(PPP-6319): Upgrade spring-security-web to 6.5.10) — commit 0136880.
- Commit: 7150e3b
- Commit: 0136880

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
