### PR TITLE
fix[SP-7316]: update log4j and log4j-slf4j2 versions to 2.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
     <!-- VERSIONS -->
     <slf4j.version>2.0.12</slf4j.version>
     <logback.version>1.3.15</logback.version>
-    <log4j.version>2.24.1</log4j.version>
-    <log4j-slf4j2.version>2.24.1</log4j-slf4j2.version>
+    <log4j.version>2.25.4</log4j.version>
+    <log4j-slf4j2.version>2.25.4</log4j-slf4j2.version>
     <commons-logging.version>1.2</commons-logging.version>
     <postgresql.version>42.5.6</postgresql.version>
 
@@ -77,7 +77,7 @@
     <osgi.compendium.version>7.0.0</osgi.compendium.version>
 
     <karaf.version>4.4.6</karaf.version>
-    <pentaho.custom.karaf.version>4.4.6-2026.05.04</pentaho.custom.karaf.version>
+    <pentaho.custom.karaf.version>4.4.6-2026.05.12</pentaho.custom.karaf.version>
 
     <felix.http.api.version>3.0.0</felix.http.api.version>
     <felix.http.proxy.version>3.0.6</felix.http.proxy.version>
@@ -130,8 +130,8 @@
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
 
-    <karaf-maven-plugin.version>4.4.6-2026.05.04</karaf-maven-plugin.version>
-    <hitachi-karaf-maven-plugin.version>4.4.6-2026.05.04</hitachi-karaf-maven-plugin.version>
+    <karaf-maven-plugin.version>4.4.6-2026.05.12</karaf-maven-plugin.version>
+    <hitachi-karaf-maven-plugin.version>4.4.6-2026.05.12</hitachi-karaf-maven-plugin.version>
     <karaf-maven-plugin.enableGeneration>true</karaf-maven-plugin.enableGeneration>
     <karaf-maven-plugin.aggregateFeatures>false</karaf-maven-plugin.aggregateFeatures>
     <karaf-maven-plugin.includeTransitiveDependency>true</karaf-maven-plugin.includeTransitiveDependency>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7316 - Backport of PPP-6425 - (10.2 Suite) Multiple Apache Log4j Vulnerabilities](https://hv-eng.atlassian.net/browse/SP-7316)
- **Base Case:** [PPP-6425 - Backport of PPP-6425 - (10.2 Suite) Multiple Apache Log4j Vulnerabilities](https://hv-eng.atlassian.net/browse/PPP-6425)
- **Original Master PR:** https://github.com/pentaho/maven-parent-poms/pull/847

## Changes
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/847
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
