### PR TITLE
build[PPP-6299]: Bump Jetty version to 12.0.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,8 +233,8 @@
     <commons-text.version>1.10.0</commons-text.version>
     <commons-net.version>3.9.0</commons-net.version>
     <aws-java-sdk.version>1.12.791</aws-java-sdk.version>
-    <jetty.version>12.0.18</jetty.version>
-    <jetty-server.version>12.0.18</jetty-server.version>
+    <jetty.version>12.0.35</jetty.version>
+    <jetty-server.version>12.0.35</jetty-server.version>
     <jetty-hadoop.version>9.4.57.v20241219</jetty-hadoop.version>
     <httpclient.version>4.5.14</httpclient.version>
     <httpclient5.version>5.4.4</httpclient5.version>


### PR DESCRIPTION
This pull request updates the Jetty dependencies in the `pom.xml` file to address CVE-2026-1605.

Dependency updates:

* Bumped `jetty.version` and `jetty-server.version` from `12.0.18` to `12.0.35` to ensure the project uses the latest stable Jetty release.