### PR TITLE
build[SP-7224]: Move dependency management of validation-api to maven parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,7 @@
     <spotbugs.version>3.1.3</spotbugs.version>
     <appscan-maven-plugin.version>1.0.7</appscan-maven-plugin.version>
     <dependency-check-maven.version>5.2.2</dependency-check-maven.version>
+    <validation-api.version>1.1.0.Final</validation-api.version>
 
     <!-- Endorsed Standards Excluded from Java 11+ -->
     <jakarta.activation.version>1.2.2</jakarta.activation.version>
@@ -1252,6 +1253,17 @@
         <groupId>jakarta.xml.ws</groupId>
         <artifactId>jakarta.xml.ws-api</artifactId>
         <version>${jakarta.xml.ws-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <version>${validation-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <version>${validation-api.version}</version>
+        <classifier>sources</classifier>
       </dependency>
 
       <!-- region gRPC -->


### PR DESCRIPTION
## Summary
- add javax.validation:validation-api version management to pentaho-parent-pom
- set the managed validation-api version to 1.1.0.Final for 10.2
- manage both the main artifact and the sources classifier for downstream consumers