### PR TITLE
build[BACKLOG-50098]: Move dependency management of org.aspectj dependencies to maven parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,8 +274,9 @@
     <spring-data-jpa.version>3.3.7</spring-data-jpa.version>
 
     <!-- AspectJ - Spring AOP weaving support -->
-    <aspectjrt.version>1.9.25.1</aspectjrt.version>
-    <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
+    <aspectj.version>1.9.25.1</aspectj.version>
+    <aspectjrt.version>${aspectj.version}</aspectjrt.version>
+    <aspectjweaver.version>${aspectj.version}</aspectjweaver.version>
 
     <enunciate-jersey-rt.version>1.27</enunciate-jersey-rt.version>
     <beanshell.version>2.1.1</beanshell.version>

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,10 @@
     <xml-apis.version>1.4.01</xml-apis.version>
     <spring-data-jpa.version>3.3.7</spring-data-jpa.version>
 
+    <!-- AspectJ - Spring AOP weaving support -->
+    <aspectjrt.version>1.9.25.1</aspectjrt.version>
+    <aspectjweaver.version>1.9.25.1</aspectjweaver.version>
+
     <enunciate-jersey-rt.version>1.27</enunciate-jersey-rt.version>
     <beanshell.version>2.1.1</beanshell.version>
 
@@ -1335,6 +1339,17 @@
         <groupId>jakarta.xml.ws</groupId>
         <artifactId>jakarta.xml.ws-api</artifactId>
         <version>${jakarta.xml.ws-api.version}</version>
+      </dependency>
+      <!-- AspectJ - Spring AOP weaving support -->
+      <dependency>
+        <groupId>org.aspectj</groupId>
+        <artifactId>aspectjrt</artifactId>
+        <version>${aspectjrt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.aspectj</groupId>
+        <artifactId>aspectjweaver</artifactId>
+        <version>${aspectjweaver.version}</version>
       </dependency>
 
       <!-- region gRPC -->


### PR DESCRIPTION
## Summary
- centralize `org.aspectj:aspectjrt` and `org.aspectj:aspectjweaver` version management in `pentaho-parent-pom` at `1.9.25.1`
- let downstream repositories inherit the managed `org.aspectj` versions from the shared parent BOM

## Validation
- `mvn -B -nsu -N clean install`
