### PR TITLE
bump apache-commons-lang3 to 3.18.0 in order to mitigate CVE-2025-48924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
     <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
     <commons-pool2.version>2.11.1</commons-pool2.version>
     <commons-vfs2.version>2.10.0</commons-vfs2.version>
-    <commons-lang3.version>3.14.0</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-text.version>1.10.0</commons-text.version>
     <commons-net.version>3.9.0</commons-net.version>


### PR DESCRIPTION
bump apache-commons-lang3 to 3.18.0 in order to mitigate CVE-2025-48924