### PR TITLE
chore: downgrade kafka-clients to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
     <dnsjava.version>3.6.0</dnsjava.version>
     <httpcore.version>4.4.11</httpcore.version>
     <httpcore5.version>5.3.4</httpcore5.version>
-    <kafka-clients.version>4.1.2</kafka-clients.version>
+    <kafka-clients.version>4.1.1</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>


### PR DESCRIPTION
Automated dependency downgrade for org.apache.kafka:kafka-clients.\n\n- Target version: 4.1.1\n- Reason: requested downgrade to next version