### PR TITLE
PPP-6626: bump netty.version to 4.1.135.Final for CVE-2026-48043

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
     <dnsjava.version>3.6.0</dnsjava.version>
     <httpcore.version>4.4.11</httpcore.version>
     <httpcore5.version>5.3.4</httpcore5.version>
-    <kafka-clients.version>4.1.2</kafka-clients.version>
+    <kafka-clients.version>4.1.1</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>

--- a/pom.xml
+++ b/pom.xml
@@ -464,7 +464,7 @@
     <amqp.version>5.22.0</amqp.version>
     <mina-core.version>2.2.8</mina-core.version>
     <saxon-he.version>12.7</saxon-he.version>
-    <netty.version>4.1.133.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <xmlresolver.version>6.0.17</xmlresolver.version>
     <xmlunit.version>1.6</xmlunit.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>


### PR DESCRIPTION
Bump netty.version from 4.1.133.Final to 4.1.135.Final to address CVE-2026-48043 / PPP-6626. Affected indexed repos inherit io.netty:netty-codec-http2 through maven-parent-poms, so the root-cause fix belongs in this shared parent POM.