### PR TITLE
build[PPP-6611]: Bump version of spring-framework dependency to 6.2.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
     <batik.version>1.17</batik.version>
 
     <!-- spring version -->
-    <spring.version>6.2.12</spring.version>
+    <spring.version>6.2.19</spring.version>
     <spring-ldap.version>3.3.8</spring-ldap.version>
     <spring-binding.version>2.4.8.RELEASE</spring-binding.version>
     <spring-se-jcr.version>0.9</spring-se-jcr.version>


### PR DESCRIPTION
## Description
Bumps `spring.version` from `6.2.12` to `6.2.19` in the shared parent BOM (`pentaho-parent-pom`).

All downstream repositories that resolve Spring Framework versions through `maven-parent-poms` will automatically inherit the updated version.

## Changes
- `pom.xml`: `<spring.version>6.2.12</spring.version>` → `6.2.19`

## Jira
[PPP-6611]

[PPP-6611]: https://hv-eng.atlassian.net/browse/PPP-6611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ