### PR TITLE
build[SP-7384]: Bump Jetty version to 12.0.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,8 +233,8 @@
     <commons-text.version>1.10.0</commons-text.version>
     <commons-net.version>3.9.0</commons-net.version>
     <aws-java-sdk.version>1.12.791</aws-java-sdk.version>
-    <jetty.version>12.0.18</jetty.version>
-    <jetty-server.version>12.0.18</jetty-server.version>
+    <jetty.version>12.0.35</jetty.version>
+    <jetty-server.version>12.0.35</jetty-server.version>
     <jetty-hadoop.version>9.4.57.v20241219</jetty-hadoop.version>
     <httpclient.version>4.5.14</httpclient.version>
     <httpclient5.version>5.4.4</httpclient5.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7384 - Backport (11.0.0.2) - CVE-2026-1605 | pdia-master has a security violation in Jetty gav://org.eclipse.jetty:jetty-server:12.0.18](https://hv-eng.atlassian.net/browse/SP-7384)
- **Base Case:** [PPP-6299 - Backport (11.0.0.2) - CVE-2026-1605 | pdia-master has a security violation in Jetty gav://org.eclipse.jetty:jetty-server:12.0.18](https://hv-eng.atlassian.net/browse/PPP-6299)
- **Original Master PR:** https://github.com/pentaho/maven-parent-poms/pull/862

## Changes
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/862
- Commit: 63abed74444df1cc8ede06a611135485b42e8960

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
