### PR TITLE
CVE-2023-48795: centralize com.github.mwiede:jsch version (0.2.26) in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
     <commons-logging.version>1.3.5</commons-logging.version>
     <postgresql.version>42.7.11</postgresql.version>
 
+    <!-- com.github.mwiede:jsch - drop-in JSch fork (keeps the com.jcraft.jsch package).
+         Centralized here so all CE + EE leaves inherit one version; CVE-2023-48795
+         (Terrapin) is fixed in >= 0.2.15. -->
+    <jsch.version>0.2.26</jsch.version>
+
     <osgi.core.version>8.0.0</osgi.core.version>
     <osgi.compendium.version>7.0.0</osgi.compendium.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,6 @@
     <commons-logging.version>1.3.5</commons-logging.version>
     <postgresql.version>42.7.11</postgresql.version>
 
-    <!-- com.github.mwiede:jsch - drop-in JSch fork (keeps the com.jcraft.jsch package).
-         Centralized here so all CE + EE leaves inherit one version; CVE-2023-48795
-         (Terrapin) is fixed in >= 0.2.15. -->
     <jsch.version>0.2.26</jsch.version>
 
     <osgi.core.version>8.0.0</osgi.core.version>


### PR DESCRIPTION
## CVE fix: CVE-2023-48795 (Terrapin) in com.github.mwiede:jsch

Tracking: https://hv-eng.atlassian.net/browse/PPP-6577
Advisory: CVE-2023-48795 / GHSA-45x7-px36-x8w8 -- Medium (CVSS 5.9), SSH prefix-truncation (Terrapin)
Change: add a single `jsch.version=0.2.26` property to `org.pentaho:pentaho-parent-pom`
Fix point: the org's root parent pom, so all CE + EE leaves inherit one version instead of each pinning `com.github.mwiede:jsch` locally.

### Why here (centralization)
`com.github.mwiede:jsch` was pinned to the vulnerable `0.2.9` independently in three leaf repos (`pentaho-kettle`, `big-data-plugin`, `pentaho-big-data-ee`). Hoisting the version to `pentaho-parent-pom` (the common ancestor of both the CE and EE chains) makes the next bump a single edit and removes the duplication. `0.2.26` clears the advisory (fixed >= 0.2.15) and has 0 known CVEs (OSV + Xray).

### Companion PRs (must land AFTER this one)
These remove their now-redundant local override and rely on the property added here. They are **blocked by this PR** and require this parent SNAPSHOT to be deployed before their CI can resolve `${jsch.version}`:
- pentaho/pentaho-kettle
- pentaho/big-data-plugin
- pentaho/pentaho-big-data-ee

### Verification
- All three leaves resolve `com.github.mwiede:jsch:jar:0.2.26:compile` after inheriting this property (verified via `help:evaluate` + `dependency:tree` with the modified parent installed locally).
- jsch API used by Pentaho (`JSch`/`Session`/`ChannelSftp`/`SftpATTRS`/`UserInfo`) is unchanged 0.2.9 -> 0.2.26; only additive (strict-kex config) + deprecations. 52 Kettle SFTP tests green on both 0.2.9 and 0.2.26.

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.
