### PR TITLE
CVE fix: CVE-2026-54428 in org.apache.httpcomponents.core5:httpcore5-h2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,8 @@
     <hadoop-shaded-protobuf_3_25.version>1.3.0</hadoop-shaded-protobuf_3_25.version>
     <dnsjava.version>3.6.0</dnsjava.version>
     <httpcore.version>4.4.11</httpcore.version>
-    <httpcore5.version>5.3.4</httpcore5.version>
+    <!-- httpcore5 (base + h2) 5.4.3 clears CVE-2026-54428 (HTTP/2 HPACK decoder DoS); 5.3.4 and earlier are vulnerable -->
+    <httpcore5.version>5.4.3</httpcore5.version>
     <kafka-clients.version>4.1.2</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>
@@ -937,6 +938,14 @@
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
+        <version>${httpcore5.version}</version>
+      </dependency>
+      <!-- Manage httpcore5-h2 in lockstep with httpcore5 so the HTTP/2 module
+           (the artifact carrying CVE-2026-54428) is pinned to the fixed version
+           instead of riding in transitively at an older, vulnerable version. -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
         <version>${httpcore5.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
## CVE fix: CVE-2026-54428 in org.apache.httpcomponents.core5:httpcore5-h2

Tracking: [PPP-6750](https://hv-eng.atlassian.net/browse/PPP-6750) — `build://pdia-master:11.1.0.0-281`
Advisory: CVE-2026-54428 — Apache HttpComponents Core, HTTP/2 HPACK decoder allocates resources without limits before the SETTINGS ACK applies the header-list-size limit → remote DoS via memory exhaustion. CVSS 3.1 7.5 (High).
Change: `org.apache.httpcomponents.core5:httpcore5` (base + `httpcore5-h2`) `5.3.4` → `5.4.3` (minimal stable clearing version; 5.4.2 and earlier are affected).
Fix point: this root parent POM (`org.pentaho:pentaho-parent-pom`) — `httpcore5.version` property + a new managed `httpcore5-h2` entry.

### Root cause
This POM managed `httpcore5` (base) via `httpcore5.version` but did **not** manage `httpcore5-h2`. `httpcore5-h2` therefore rode in transitively via `org.apache.httpcomponents.client5:httpclient5:5.4.4` (whose parent pins httpcore `5.3.4`), so the vulnerable `httpcore5-h2-5.3.4.jar` shipped. `httpclient5` itself is not affected by this CVE.

### Fix
1. `httpcore5.version` `5.3.4` → `5.4.3`.
2. Add a managed `httpcore5-h2` dependency pinned to `${httpcore5.version}`, keeping base and h2 in lockstep at the fixed version for every consumer inheriting this parent (regardless of transitive origin).

### Dependency tree (before → after)
Verified with a probe module inheriting `pentaho-ce-jar-parent-pom` (reproduces the `kettle-core` path):
```
BEFORE:  httpclient5:5.4.4 -> httpcore5-h2:5.3.4:compile   (vulnerable)
         httpcore5:5.3.4
AFTER:   httpclient5:5.4.4 -> httpcore5-h2:5.4.3:compile   (fixed)
         httpcore5:5.4.3       — no 5.3.4 anywhere
```

### Tests / risk
`maven-parent-poms` is POM-only (no unit tests). 5.3.4 → 5.4.3 is a binary-compatible minor bump within the HttpComponents Core 5.x line; `httpclient5:5.4.4` resolves cleanly against httpcore `5.4.3`. An org-wide code search found **no** first-party usage of `org.apache.hc.core5.http2` — `httpcore5-h2` is a pure runtime jar, so no source adaptation is needed. Verification is the before/after dependency-tree proof above (same approach used for prior parent-POM version bumps).

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.

[PPP-6750]: https://hv-eng.atlassian.net/browse/PPP-6750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ