### PR TITLE
build[PPP-6754]: Bump httpcore5 to 5.4.3 and manage httpcore5-h2 (CVE-2026-54399 + CVE-2026-54428)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -939,6 +939,14 @@
         <artifactId>httpcore5</artifactId>
         <version>${httpcore5.version}</version>
       </dependency>
+      <!-- Manage httpcore5-h2 in lockstep with httpcore5 so the HTTP/2 module
+           (the artifact carrying CVE-2026-54428) is pinned to the fixed version
+           instead of riding in transitively at an older, vulnerable version. -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${httpcore5.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
     <hadoop-shaded-protobuf_3_25.version>1.3.0</hadoop-shaded-protobuf_3_25.version>
     <dnsjava.version>3.6.0</dnsjava.version>
     <httpcore.version>4.4.11</httpcore.version>
-    <httpcore5.version>5.3.4</httpcore5.version>
+    <httpcore5.version>5.4.3</httpcore5.version>
     <kafka-clients.version>4.1.2</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>


### PR DESCRIPTION
### What

Centralizes and bumps the Apache HttpComponents Core 5 dependencies in the parent POM (single source of truth / BOM):

- `httpcore5.version` `5.3.4` → `5.4.3`
- Adds a managed `httpcore5-h2` entry pinned to `${httpcore5.version}` so the HTTP/2 module is kept in lockstep with the base module.

### Why

Covers **two** CVEs with one parent-POM change:

- **CVE-2026-54399** (Jira: **PPP-6754**) — base `httpcore5`.
- **CVE-2026-54428** (`httpcore5-h2`) — the HTTP/2 module was previously **unmanaged**, so it rode in transitively via `httpclient5:5.4.4` at the vulnerable `5.3.4`. Managing it in lockstep pins it to the fixed `5.4.3` for every inheriting consumer.

> Supersedes #903 (same base bump + h2 management). #903 can be closed as redundant.

### Changes

- `pom.xml`: `httpcore5.version` → `5.4.3`; new `httpcore5-h2` `dependencyManagement` entry pinned to `${httpcore5.version}`.

### Validation

- `mvn -B -nsu -Dmaven.test.skip=true clean install` — BUILD SUCCESS.
- Dependency tree in a consumer (`kettle-core`), before → after:
  ```
  BEFORE:  httpclient5:5.4.4 -> httpcore5-h2:5.3.4   (vulnerable)
           httpcore5:5.3.4
  AFTER:   httpcore5:5.4.3
           httpcore5-h2:5.4.3   (pinned, no 5.3.4 anywhere)
  ```
- `httpcore5-h2` is a pure runtime jar; no first-party usage of `org.apache.hc.core5.http2`, so no source changes needed.

### Notes

- `httpclient5` (5.4.4) is unchanged and resolves cleanly against httpcore 5.4.3.
