### PR TITLE
CVE fix: CVE-2021-28170 in org.glassfish:javax.el (manage com.cronutils:cron-utils 9.1.7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -478,10 +478,20 @@
     <!-- poi  -->
     <poi.version>5.5.1</poi.version>
 
+    <!-- cron-utils 9.1.7+ depends on the fixed org.glassfish:jakarta.el 3.0.4 instead of the
+         vulnerable org.glassfish:javax.el 3.0.0 (CVE-2021-28170). Managed centrally so every
+         consumer inherits the patched transitive Expression Language implementation. -->
+    <cronutils.version>9.1.7</cronutils.version>
+
   </properties>
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.cronutils</groupId>
+        <artifactId>cron-utils</artifactId>
+        <version>${cronutils.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-continuation</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,7 @@
     <!-- cron-utils 9.1.7+ depends on the fixed org.glassfish:jakarta.el 3.0.4 instead of the
          vulnerable org.glassfish:javax.el 3.0.0 (CVE-2021-28170). Managed centrally so every
          consumer inherits the patched transitive Expression Language implementation. -->
-    <cronutils.version>9.1.7</cronutils.version>
+    <cron-utils.version>9.1.7</cron-utils.version>
 
   </properties>
 
@@ -490,7 +490,7 @@
       <dependency>
         <groupId>com.cronutils</groupId>
         <artifactId>cron-utils</artifactId>
-        <version>${cronutils.version}</version>
+        <version>${cron-utils.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
## CVE fix: CVE-2021-28170 in `org.glassfish:javax.el` (via `com.cronutils:cron-utils`)

Advisory: CVE-2021-28170 / GHSA-v6w3-2prq-h95f — **Medium** (CVSS 5.3, CWE-20/CWE-917)
Jira: PPP-6565, PPP-5971
Change: manage `com.cronutils:cron-utils` at **9.1.7** in the org root parent POM (`org.pentaho:pentaho-parent-pom`).

### Why this fixes the CVE
`org.glassfish:javax.el:3.0.0` is not declared directly anywhere in the org — it is pulled **transitively** by `com.cronutils:cron-utils:9.1.6`. There is **no fixed `3.0.4` under the `org.glassfish:javax.el` artifactId** (the artifact was renamed to `org.glassfish:jakarta.el`). `cron-utils:9.1.7` instead depends on the fixed **`org.glassfish:jakarta.el:3.0.4`**, which is a **binary drop-in**: it retains the `javax.el.*` package namespace (49 classes under `javax/el/`, zero `jakarta/el/` — the Jakarta EE 8 line), so no consumer code changes are required.

This PR centralizes the version so every consumer inherits the patched transitive EL implementation and removes duplicated leaf overrides.

### Companion PRs (remove the leaf `9.1.6` overrides — must merge after this one is published)
- pentaho/pentaho-kettle — `engine/pom.xml`
- pentaho/pentaho-platform — `extensions/pom.xml`
- pentaho/pentaho-scheduler-plugin — `core/pom.xml` (+ EL-path regression test)

> ⚠️ **Merge order:** this parent-POM PR must merge and publish a new `11.1.0.0-SNAPSHOT` **first**; the three leaf PRs drop their `<version>` and won't resolve `cron-utils` until the managed version is available.

### Dependency tree (before → after) — verified at all three fix-points
```
before: com.cronutils:cron-utils:9.1.6 -> org.glassfish:javax.el:3.0.0   (vulnerable)
after:  com.cronutils:cron-utils:9.1.7 -> org.glassfish:jakarta.el:3.0.4 (fixed)
```
`org.glassfish:javax.el:3.0.0` is **absent on every path** (verbose `dependency:tree`) in `pentaho-kettle/engine`, `pentaho-platform/extensions`, and `pentaho-scheduler-plugin/core`, resolved `-nsu` against a locally-installed build of this change.

### Review
Fixed and reviewed locally via `codemedic-local-remediator` before push.
