### PR TITLE
CVE fix: CVE-2020-15250 in junit:junit

### DIFF
--- a/pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pom.xml
+++ b/pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <!-- VERSIONS -->
-    <junit.version>4.11</junit.version>
+    <junit.version>4.13.1</junit.version>
 
     <!-- http://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html -->
     <maven.test.failure.ignore>false</maven.test.failure.ignore>


### PR DESCRIPTION
## CVE fix: CVE-2020-15250 in junit:junit

Tracking: [PPP-6561](https://pentaho-eng.atlassian.net/browse/PPP-6561)
Advisory: CVE-2020-15250 (aliases: GHSA-269g-pwp5-87pp) -- Medium (CVSS 4.4), CWE-200/CWE-732
Change: `junit:junit` `4.11` -> `4.13.1` (minimal clearing version; fixed line: 3.1.1, 4.13.1)
Fix point: `pentaho-ce-parent-pom/pentaho-ce-jar-parent-pom/pom.xml`, property `junit.version`

### Why here
Org-wide code search (Iron Law 9) confirmed this is the **sole** definition of `junit.version` reachable from `pentaho-reporting` (the repo whose `pre-classic-sdk` SDK samples zip ships the flagged `junit-4.11.jar`, via `assemblies/sdk` -> `assemblies/samples` -> `maven-dependency-plugin:copy-dependencies`). `pentaho-reporting`'s root POM inherits `org.pentaho:pentaho-ce-jar-parent-pom` directly, with **zero leaf overrides** anywhere in the repo (root pom, `engine/pom.xml`, `engine/core/pom.xml` all reference `${junit.version}`), and zero hardcoded `4.11` literals.

A separate, architecturally-independent `junit.version=4.11` pin also exists in `maven-parent-poms-ee`'s `pentaho-ee-jar-parent-pom/pom.xml` (different parent chain: `com.pentaho:pentaho-ee-parent-pom`). It is **not** implicated by the given CE-only impact path and is intentionally left untouched by this PR.

### Risk assessment (research-upgrade: proceed)
JUnit is test-scope-only across `pentaho-reporting` (confirmed zero first-party `import org.junit` in main source). The 4.11->4.13.1 delta stays within the stable JUnit4 4.x API line (no removed/changed public API used here); the CVE fix itself is internal `TemporaryFolder` hardening (stricter POSIX file permissions on Java 7+), not an API or behavior change exposed to consumers. Contained, low blast radius.

### Dependency tree (before -> after)
Proven via a minimal synthetic module inheriting this same parent (avoids needing the full `pentaho-reporting` reactor -- valid since Maven property resolution is identical for every consumer):
```
BEFORE: junit:junit:jar:4.11:test
AFTER:  junit:junit:jar:4.13.1:test
```
(Broader `-Dincludes=junit` filter confirms no other `junit` coordinate remains on the path.)

### Tests
This is a POM-only parent-pom repo with no application tests of its own. Baseline-green / post-bump-green proof: `mvn -N install` succeeded at all three parent tiers (root -> `pentaho-ce-parent-pom` -> `pentaho-ce-jar-parent-pom`) both before and after the property edit.

### Review
Fixed and reviewed locally via `codemedic-local-remediator` before push; developer explicitly approved this diff via the local review gate prior to pushing.


[PPP-6561]: https://pentaho-eng.atlassian.net/browse/PPP-6561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ