### PR TITLE
[PPP-6787] Bump log4j 2.25.4 -> 2.25.5 (CVE-2026-49844)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
     <!-- VERSIONS -->
     <slf4j.version>2.0.12</slf4j.version>
     <logback.version>1.3.15</logback.version>
-    <log4j.version>2.25.4</log4j.version>
-    <log4j-slf4j2.version>2.25.4</log4j-slf4j2.version>
+    <log4j.version>2.25.5</log4j.version>
+    <log4j-slf4j2.version>2.25.5</log4j-slf4j2.version>
     <commons-logging.version>1.3.5</commons-logging.version>
     <postgresql.version>42.7.11</postgresql.version>
 


### PR DESCRIPTION
## CVE-2026-49844 — Apache Log4j API MapMessage JSON non-finite float encoding

Jira: [PPP-6787](https://pentaho-eng.atlassian.net/browse/PPP-6787) · Build: `pdia-master`

### What
Bumps the org-wide log4j baseline in this universal parent pom:
- `log4j.version` **2.25.4 → 2.25.5**
- `log4j-slf4j2.version` **2.25.4 → 2.25.5**

Both properties drive every managed `org.apache.logging.log4j:*` artifact (`log4j-api`, `log4j-core`, `log4j-slf4j-impl`, `log4j-slf4j2-impl`, `log4j-1.2-api`, `log4j-jcl`) in `<dependencyManagement>`.

### Why
CVE-2026-49844: `MapMessage.asJson()` emits bare `NaN`/`Infinity`/`-Infinity` tokens, producing non-RFC 8259 JSON (a follow-up gap left by CVE-2026-34481). Affects log4j-api **2.13.1–2.25.4** and **2.26.0**. **2.25.5** emits compliant JSON — the minimal patch on the current 2.25.x line (lowest blast radius; same minor, binary-compatible).

### Proof
`pentaho-parent-pom` is the universal CE+EE root. Installed the modified parent chain locally and re-resolved a CE consumer:

`pentaho-kettle/core` `dependency:tree`:
- before (published parent): `log4j-core:2.25.4:provided`, `log4j-api:2.25.4:provided`
- after: `log4j-core:2.25.5:provided`, `log4j-api:2.25.5:provided`

The EE parent chain (`maven-parent-poms-ee`) roots at this same `org.pentaho:pentaho-parent-pom`, so it inherits the new version with no EE-side change.

### Scope
Minimal — the two version properties only. No other files touched.

---
Reviewed locally before push (codemedic-local-remediator). Verification (D48) is pending re-analysis of a newer `pdia-master` build.

[PPP-6787]: https://pentaho-eng.atlassian.net/browse/PPP-6787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ