### PR TITLE
build[SP-7399]: bump tomcat to 9.0.120

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
 
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
-    <tomcat.version>9.0.118</tomcat.version>
+    <tomcat.version>9.0.120</tomcat.version>
     <pax-web.version>8.0.32</pax-web.version>
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->


### PR DESCRIPTION
### Summary
Backport of PPP-6742 to the **10.2** maintenance branch.

Upgrades Tomcat from `9.0.118` to [`9.0.120`](https://mvnrepository.com/artifact/org.apache.tomcat/tomcat-catalina/9.0.120) to address [CVE-2026-53434](https://nvd.nist.gov/vuln/detail/CVE-2026-53434).

### Context
The base fix (PPP-6739 / PR #901) bumped Tomcat to `10.1.56` on the **10.1.x** line, which does not apply to the `10.2` branch. The `10.2` maintenance branch intentionally tracks the Tomcat **9.0.x** line (per prior backport SP-7360). This PR therefore applies the equivalent patch on the 9.0.x line (`9.0.120`), which contains the fix for CVE-2026-53434.

### Details
- **Jira:** SP-7399 (base case PPP-6742)
- **Target branch:** `10.2` (maintenance only)
- **Change:** `<tomcat.version>` `9.0.118` → `9.0.120`

### Policy
- Backport target is maintenance branch only: `10.2`.
- Does not target the SP branch.