### PR TITLE
build[SP-7400]: bump tomcat to 10.1.57

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
 
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
-    <tomcat.version>10.1.56</tomcat.version>
+    <tomcat.version>10.1.57</tomcat.version>
     <pax-web.version>8.0.32</pax-web.version>
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
 
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->
-    <tomcat.version>10.1.55</tomcat.version>
+    <tomcat.version>10.1.56</tomcat.version>
     <pax-web.version>8.0.32</pax-web.version>
     <!-- Some pax-web components have dependencies on Tomcat components: be sure to sync both versions -->
     <!-- Karaf uses pax-web: be sure to use the custom hitachi karaf with the same version -->


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7400 - Backport of PPP-6742 - (11.0 Suite) CVE-2026-53434 | pdia-master has a security violation in gav://org.apache.tomcat.embed:tomcat-embed-core:10.1.55](https://pentaho-eng.atlassian.net/browse/SP-7400)
- **Base Case:** [PPP-6742 - Backport of PPP-6742 - (11.0 Suite) CVE-2026-53434 | pdia-master has a security violation in gav://org.apache.tomcat.embed:tomcat-embed-core:10.1.55](https://pentaho-eng.atlassian.net/browse/PPP-6742)
- **Original Master PR:** https://github.com/pentaho/maven-parent-poms/pull/901

Update: Since meanwhile there was a bump to 10.1.57, I updated this PR manually with the commit https://github.com/pentaho/maven-parent-poms/commit/a06d811a1e7dfb32c674dadf41848cf257a09475

## Changes
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/901
- Commit: 63b61c282a46ae5257572d031fcf258199daa379

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
