### PR TITLE
build[SP-7410]: Update ActiveMQ version to 5.19.5 (#835)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <pax-url-aether.version>2.6.16</pax-url-aether.version>
     <cxf.version>3.6.8</cxf.version>
 
-    <activemq.version>5.18.7</activemq.version>
+    <activemq.version>5.19.5</activemq.version>
 
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>


### PR DESCRIPTION
Bump ActiveMQ version from 5.8.17 to 5.19.5, in order to address CVE-2026-34197

SP-7410

Original PR: #835 