### PR TITLE
fix[SP-7438]: update activemq version to 5.19.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <pax-url-aether.version>2.6.16</pax-url-aether.version>
     <cxf.version>3.6.8</cxf.version>
 
-    <activemq.version>5.18.7</activemq.version>
+    <activemq.version>5.19.7</activemq.version>
 
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7438 - Backport of PPP-6445 - (10.2 Suite) CVE-2026-40466 | pdia-master has a security violation in Apache ActiveMQ build://pdia-master:11.1.0.0-212](https://pentaho-eng.atlassian.net/browse/SP-7438)
- **Base Case:** [PPP-6445 - Backport of PPP-6445 - (10.2 Suite) CVE-2026-40466 | pdia-master has a security violation in Apache ActiveMQ build://pdia-master:11.1.0.0-212](https://pentaho-eng.atlassian.net/browse/PPP-6445)
- **Original Master PR:** https://github.com/pentaho/maven-parent-poms/pull/883

## Changes
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/883
- Commit: 5c7328ff548badd3a6416da2e90b31667a4de57e

## Conflict Resolution
- Conflict at `5c7328ff548b` (fix[PPP-6445]: update activemq version to 5.19.7): resolved in `pom.xml`

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
