### PR TITLE
fix[SP-7439]: update activemq version to 5.19.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <pax-url-aether.version>3.0.3</pax-url-aether.version>
     <cxf.version>3.6.8</cxf.version>
 
-    <activemq.version>5.19.5</activemq.version>
+    <activemq.version>5.19.7</activemq.version>
     <byte-buddy.version>1.17.6</byte-buddy.version>
     <maven-filtering.version>3.3.1</maven-filtering.version>
     <javassist.version>3.30.2-GA</javassist.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7439 - Backport of PPP-6445 - (11.0 Suite) CVE-2026-40466 | pdia-master has a security violation in Apache ActiveMQ build://pdia-master:11.1.0.0-212](https://pentaho-eng.atlassian.net/browse/SP-7439)
- **Base Case:** [PPP-6445 - Backport of PPP-6445 - (11.0 Suite) CVE-2026-40466 | pdia-master has a security violation in Apache ActiveMQ build://pdia-master:11.1.0.0-212](https://pentaho-eng.atlassian.net/browse/PPP-6445)
- **Original Master PR:** https://github.com/pentaho/maven-parent-poms/pull/883

## Changes
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/883
- Commit: 5c7328ff548badd3a6416da2e90b31667a4de57e

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
