### PR TITLE
fix(SP-7409): CVE-2026-35554 | pdia-master has a security violation in gav://org.apache.kafka:kafka-clients:3.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <dnsjava.version>3.6.0</dnsjava.version>
     <httpcore.version>4.4.11</httpcore.version>
     <httpcore5.version>5.3.4</httpcore5.version>
-    <kafka-clients.version>3.9.1</kafka-clients.version>
+    <kafka-clients.version>4.1.2</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>
     <org.apache.avro.version>1.12.0</org.apache.avro.version>


### PR DESCRIPTION
Backport of PPP-6393 to 10.2.

Bumps `kafka-clients.version` from 3.9.1 to 4.1.2 to remediate CVE-2026-35554.

## Policy
- Backport target is maintenance branch only: 10.2
- Source PR: pentaho/maven-parent-poms#884