### PR TITLE
build[SP-7461]: Bump httpcore5 to 5.4.3 and manage httpcore5-h2 (CVE-2026-54399 + CVE-2026-54428)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
     <hadoop-shaded-protobuf_3_25.version>1.3.0</hadoop-shaded-protobuf_3_25.version>
     <dnsjava.version>3.6.0</dnsjava.version>
     <httpcore.version>4.4.11</httpcore.version>
-    <httpcore5.version>5.3.4</httpcore5.version>
+    <httpcore5.version>5.4.3</httpcore5.version>
     <kafka-clients.version>4.1.2</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>
@@ -928,6 +928,14 @@
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
+        <version>${httpcore5.version}</version>
+      </dependency>
+      <!-- Manage httpcore5-h2 in lockstep with httpcore5 so the HTTP/2 module
+           (the artifact carrying CVE-2026-54428) is pinned to the fixed version
+           instead of riding in transitively at an older, vulnerable version. -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
         <version>${httpcore5.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7461 - Backport of PPP-6754 - (11.0 Suite) CVE-2026-54399 | pdia-master has a security violation in gav://org.apache.httpcomponents.core5:httpcore5:5.3.4](https://pentaho-eng.atlassian.net/browse/SP-7461)
- **Base Case:** [PPP-6754 - Backport of PPP-6754 - (11.0 Suite) CVE-2026-54399 | pdia-master has a security violation in gav://org.apache.httpcomponents.core5:httpcore5:5.3.4](https://pentaho-eng.atlassian.net/browse/PPP-6754)
- **Original Master PR:** https://github.com/pentaho/maven-parent-poms/pull/905

## Changes
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/905
- Commit: 873d165a55bf02e91387fda1ad3fe76bf9ff3a76

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
