### PR TITLE
[CVE-2026-56624] Bump org.apache.sshd from 2.16.0 to 2.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
     <commons-io.version>2.18.0</commons-io.version>
     <hsqldb.version>2.7.4</hsqldb.version>
     
-    <apache-sshd.version>2.16.0</apache-sshd.version>
+    <apache-sshd.version>2.19.0</apache-sshd.version>
 
     <lz4-java.version>1.10.3</lz4-java.version>
 


### PR DESCRIPTION
## CVE-2026-56624 — Improper certificate validation in Apache MINA SSHD (server-side)

**Component:** `org.apache.sshd:sshd-core` @ 2.16.0 (maven)
**Fixed version:** 2.19.0
**Severity:** High | CVSS 7.3 | CWE-295

Server-side OpenSSH user certificate validation during authentication did not check for the unsupported `force-command`/`verify-required` options embedded in the certificate. A user could authenticate with such a certificate and still execute other commands. Fixed upstream in Apache MINA SSHD 2.19.0.

### Fix

`apache-sshd.version` is the single `dependencyManagement`-controlled property for `sshd-core`/`sshd-scp`/`sshd-sftp`, consumed at runtime by `pentaho-kettle` (engine), `big-data-plugin`, `pentaho-metadata-editor(-ee)`, and `pentaho-reporting` via their own `pom.xml` direct dependency declarations (no explicit version — inherited from this property). Bumping it here fixes the CVE centrally for all consumers in one place (no leaf-module overrides needed).

### Verification

- **Baseline (2.16.0):** built `pentaho-kettle`'s `engine` module against the current parent and ran the SSH-related unit tests — 68/68 green (`SSHDataTest`, `SshProxyConfigurationTest`, `MinaSshConnectionEdgeCasesTest`, `MinaSftpSessionTest`, `SshStepMigrationTest`).
- **After bump:** installed this patched parent locally and rebuilt `pentaho-kettle`'s `engine` module against it — same 68/68 tests still green.
- **Dependency tree proof:** `mvn dependency:tree -Dincludes=org.apache.sshd` on `engine` now resolves `sshd-core`, `sshd-common`, and `sshd-sftp` all to `2.19.0` — the vulnerable `2.16.0` is absent on every path.
- **Upgrade risk assessment:** reviewed the Apache MINA SSHD release notes for 2.17.0, 2.18.0, and 2.19.0. No breaking API/behavior changes affect Pentaho's usage (`SshClient`, `SftpClient`, `SSHData`/`SSHMeta` job entry, key-based/password auth). The only "Potential Compatibility Issues" entries concern `sshd-git`'s `GitPgmCommandFactory` (unused here) and OpenSSH certificate handling defaults (Pentaho does not use OpenSSH certificate-based auth). Verdict: contained, low blast radius.

A related CVE (CVE-2026-56452, `sshd-scp` path traversal) affecting the same `pdia-master` build is fixed separately in pentaho/pentaho-karaf-assembly#857 (that coordinate ships independently via the Karaf `ssh` feature, not through this managed property).

---
Produced by `codemedic-local-remediator`, reviewed locally with the developer before push.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-377", "items": [{"cve": "CVE-2026-56624", "coordinate": "org.apache.sshd:sshd-core"}]} -->
