### PR TITLE
chore[SP-7490]: Bump log4j 2.25.4 -> 2.25.5 (CVE-2026-49844)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
     <!-- VERSIONS -->
     <slf4j.version>2.0.12</slf4j.version>
     <logback.version>1.3.15</logback.version>
-    <log4j.version>2.25.4</log4j.version>
-    <log4j-slf4j2.version>2.25.4</log4j-slf4j2.version>
+    <log4j.version>2.25.5</log4j.version>
+    <log4j-slf4j2.version>2.25.5</log4j-slf4j2.version>
     <commons-logging.version>1.2</commons-logging.version>
     <postgresql.version>42.7.11</postgresql.version>
 


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7490 - Backport of PPP-6787 - (10.2 Suite) CVE-2026-49844 -  pdia-master has a vulnerability in log4j](https://pentaho-eng.atlassian.net/browse/SP-7490)
- **Base Case:** [PPP-6787 - Backport of PPP-6787 - (10.2 Suite) CVE-2026-49844 -  pdia-master has a vulnerability in log4j](https://pentaho-eng.atlassian.net/browse/PPP-6787)
- **Original Master PR:** https://github.com/pentaho/maven-parent-poms/pull/918

## Changes
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/918
- Commit: 83b1bad58e7181144ae162bad5df7381964e3bae

## Conflict Resolution
- Conflict at `83b1bad58e71` ([PPP-6787] Bump log4j 2.25.4 -> 2.25.5 (CVE-2026-49844)): resolved in `pom.xml`

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)


[PPP-6787]: https://pentaho-eng.atlassian.net/browse/PPP-6787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ