### PR TITLE
build[SP-7537]: Bump Jetty from 12.0.35 to 12.0.37

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,8 +233,8 @@
     <commons-text.version>1.10.0</commons-text.version>
     <commons-net.version>3.9.0</commons-net.version>
     <aws-java-sdk.version>1.12.791</aws-java-sdk.version>
-    <jetty.version>12.0.35</jetty.version>
-    <jetty-server.version>12.0.35</jetty-server.version>
+    <jetty.version>12.0.37</jetty.version>
+    <jetty-server.version>12.0.37</jetty-server.version>
     <jetty-hadoop.version>9.4.57.v20241219</jetty-hadoop.version>
     <httpclient.version>4.5.14</httpclient.version>
     <httpclient5.version>5.4.4</httpclient5.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7537 - Backport of PPP-6862 - (11.0 Suite) CVE-2026-10050 - (Pentaho 11.0 PDI, Platform) Jetty](https://pentaho-eng.atlassian.net/browse/SP-7537)
- **Base Case:** [PPP-6862 - Backport of PPP-6862 - (11.0 Suite) CVE-2026-10050 - (Pentaho 11.0 PDI, Platform) Jetty](https://pentaho-eng.atlassian.net/browse/PPP-6862)
- **Original Master PR:** https://github.com/pentaho/maven-parent-poms/pull/937

## Changes
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/937
- Commit: 97462b6a04f09c173b8926bbd674a8378c715333

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
