### PR TITLE
build[SP-7536]: Bump version of spring-framework dependency to 6.2.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
     <batik.version>1.17</batik.version>
 
     <!-- spring version -->
-    <spring.version>6.2.12</spring.version>
+    <spring.version>6.2.19</spring.version>
     <spring-ldap.version>3.3.3</spring-ldap.version>
     <spring-binding.version>2.4.8.RELEASE</spring-binding.version>
     <spring-se-jcr.version>0.9</spring-se-jcr.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7536 - Backport of PPP-6611 - (11.0 Suite) CVE-2026-41850 | pdia-master has a security violation in Spring Framework build://pdia-master:11.1.0.0-257](https://pentaho-eng.atlassian.net/browse/SP-7536)
- **Base Case:** [PPP-6611 - Backport of PPP-6611 - (11.0 Suite) CVE-2026-41850 | pdia-master has a security violation in Spring Framework build://pdia-master:11.1.0.0-257](https://pentaho-eng.atlassian.net/browse/PPP-6611)
- **Original Master PR:** https://github.com/pentaho/maven-parent-poms/pull/890

## Changes
- Cherry-picked from https://github.com/pentaho/maven-parent-poms/pull/890
- Commit: not provided

## Conflict Resolution
- Conflict at `b77c904f35de` (build[PPP-6611]: Bump version of spring-framework dependency to 6.2.19 (#890)): resolved in `pom.xml`

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
