### PR TITLE
build[PPP-6913][PPP-6992][PPP-7000][PPP-7059]: bump Bouncy Castle to 1.85 / bcprov to 1.85.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,8 @@
     <!-- jdk14 and jdk15on versions not to be used; supports older third-party pom files in build -->
     <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
     <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
-    <bouncycastle.version>1.84</bouncycastle.version>
+    <bouncycastle.version>1.85</bouncycastle.version>
+    <bcprov.version>1.85.2</bcprov.version>
     <simple-jndi.version>1.0.14</simple-jndi.version>
     <json-smart.version>2.5.2</json-smart.version>
     <json-simple.version>1.1.1</json-simple.version>
@@ -1176,7 +1177,7 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15to18</artifactId>
-        <version>${bouncycastle.version}</version>
+        <version>${bcprov.version}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
@@ -1197,6 +1198,11 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${bcprov.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -251,10 +251,6 @@
     <h2.version>2.2.224</h2.version>
     <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <!-- jdk14 and jdk15on versions not to be used; supports older third-party pom files in build -->
-    <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
-    <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>
-    <bouncycastle.version>1.85</bouncycastle.version>
-    <bcprov.version>1.85.2</bcprov.version>
     <bcprov-jdk14.version>1.85.2</bcprov-jdk14.version>
     <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
     <bouncycastle.version>1.85</bouncycastle.version>


### PR DESCRIPTION
Opened by CodeMedic for build `pdia-master@11.1.0.0-370`.

## CVEs cleared

| CVE | Aliases | Severity | Coordinates |
|---|---|---|---|
| CVE-2026-59638 | PPP-6913 | Critical | `bcprov-jdk15to18`, `bcprov-jdk18on` |
| CVE-2026-58062 | PPP-7059 | Critical | `bcprov-jdk15to18`, `bcprov-jdk18on` |
| CVE-2026-59650 | PPP-7000 | Critical | `bcprov-jdk15to18`, `bcprov-jdk18on` |
| CVE-2026-8763  | PPP-6992 | Critical | `bcprov-jdk15to18`, `bcprov-jdk18on` |

Advisories: https://osv.dev/vulnerability/CVE-2026-59638 - https://osv.dev/vulnerability/CVE-2026-58062 - https://osv.dev/vulnerability/CVE-2026-59650 - https://osv.dev/vulnerability/CVE-2026-8763
Upstream release notes: https://github.com/bcgit/bc-java/blob/main/docs/releasenotes.html

## Why this is the right fix point

An org-wide source search found only **two** places in `pentaho`/`webdetails` that hold a literal Bouncy Castle `1.84`: this pom and `pentaho-ee-license` (a standalone `com.pentaho` chain that does not inherit from here, fixed in its own PR). Every other consumer - `pentaho-kettle`, `pentaho-platform(-ee)`, `big-data-plugin`, `pentaho-big-data-ee`, `pentaho-hadoop-shims` and the shim drivers, `pdi-plugins-ee`, `modeler` - either declares BC with no version under this `dependencyManagement` or receives it transitively, so they are fixed by this change alone.

The karaf assemblies also inherit it for free: their `bundleReplacement` entries are filtered from `${bouncycastle.version}` as `originalUri="mvn:org.bouncycastle/bcprov-jdk18on/[1.71.1,${bouncycastle.version})"` -> `replacement=".../${bouncycastle.version}"`. With the property at 1.85 the range becomes `[1.71.1,1.85)`, which still captures the 1.84 bundle and rewrites it to a fixed version.

## Why two properties

All four CVEs are fixed in **1.85**. Bouncy Castle did **not** re-release the whole family past that point - 1.85.1 and 1.85.2 are per-artifact patch releases:

| Artifact | Published 1.85.x |
|---|---|
| `bcprov-jdk15to18` | 1.85, 1.85.1, **1.85.2** |
| `bcprov-jdk18on` | 1.85, **1.85.2** |
| `bcutil-jdk15to18` | 1.85, 1.85.1 |
| `bcpkix-*`, `bcmail-*`, `bcutil-jdk18on` | 1.85 only |

Setting a single `bouncycastle.version=1.85.2` therefore fails to resolve - the family would be missing four of its members. The shared property moves to `1.85` and `bcprov` gets its own `bcprov.version=1.85.2`, which is the version Xray recommends and the one that fixes the `AES$CBC256` / `id_aes256_CBC` defect that silently derived a 192-bit key instead of 256 (bcgit/bc-java#2390). Same release line, so no binary skew across the family.

`bcprov-jdk18on` is the second flagged coordinate but had no managed entry - it only arrived transitively through `bcpkix-jdk18on`, so its version was whatever that pulled in. It is now managed explicitly.

## Dependency tree

Verified by installing the modified root pom and resolving a probe module that inherits it.

Before:
```
org.bouncycastle:bcprov-jdk15to18:jar:1.84
org.bouncycastle:bcmail-jdk15to18:jar:1.84
org.bouncycastle:bcpkix-jdk15to18:jar:1.84
org.bouncycastle:bcutil-jdk15to18:jar:1.84
org.bouncycastle:bcpkix-jdk18on:jar:1.84
  \- org.bouncycastle:bcutil-jdk18on:jar:1.84
     \- org.bouncycastle:bcprov-jdk18on:jar:1.84
```

After:
```
org.bouncycastle:bcprov-jdk15to18:jar:1.85.2:compile
org.bouncycastle:bcmail-jdk15to18:jar:1.85:compile
org.bouncycastle:bcpkix-jdk15to18:jar:1.85:compile
org.bouncycastle:bcutil-jdk15to18:jar:1.85:compile
org.bouncycastle:bcpkix-jdk18on:jar:1.85:compile
  \- org.bouncycastle:bcutil-jdk18on:jar:1.85:compile
     \- org.bouncycastle:bcprov-jdk18on:jar:1.85.2:compile
```

Both flagged coordinates land on 1.85.2; no 1.84 remains on any path.

## Testing

This repo ships poms only, so there is no test suite to harden here. The behavioural gate for the upgrade lives in the sibling `pentaho-ee-license` PR, where 13 error-path tests over the CMS/PKIX code paths were written and proved green on the vulnerable 1.84 baseline **before** the version moved, then re-run green on 1.85/1.85.2.

## Notes for the reviewer

This property is inherited very widely, so the blast radius is the real review question rather than the diff. The upgrade was assessed as contained: Bouncy Castle is consumed internally through the JCA/CMS/PKIX APIs and no first-party service API, wire protocol or serialized format exposes BC types to downstream consumers.

Behavioural deltas in 1.85 that could plausibly surface somewhere in the estate: stricter `GeneralName`/`ediPartyName` ASN.1 tagging (previously-accepted encodings now rejected), name-constraint trailing-dot handling, the JSSE hostname-verifier CN fallback becoming opt-in, OCSP stapling now bound to the checked certificate, and S/MIME `withHeader` rejecting CRLF. Downstream CI is the honest check on those.

Out of scope but recorded: `pentaho/smbj` pins `bcprov-jdk18on:1.78.1` in `gradle.properties`, but `pdi-plugins-ee` excludes it; `pentaho/pdi-openlineage-plugin-ee` pins bcprov/bcpkix-jdk18on 1.84 in **test scope only** on the 10.2 train.

Not auto-merged - this needs a human review.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-370", "items": [{"cve": "CVE-2026-59638", "coordinate": "org.bouncycastle:bcprov-jdk15to18"}, {"cve": "CVE-2026-59638", "coordinate": "org.bouncycastle:bcprov-jdk18on"}, {"cve": "CVE-2026-58062", "coordinate": "org.bouncycastle:bcprov-jdk15to18"}, {"cve": "CVE-2026-58062", "coordinate": "org.bouncycastle:bcprov-jdk18on"}, {"cve": "CVE-2026-59650", "coordinate": "org.bouncycastle:bcprov-jdk15to18"}, {"cve": "CVE-2026-59650", "coordinate": "org.bouncycastle:bcprov-jdk18on"}, {"cve": "CVE-2026-8763", "coordinate": "org.bouncycastle:bcprov-jdk15to18"}, {"cve": "CVE-2026-8763", "coordinate": "org.bouncycastle:bcprov-jdk18on"}]} -->
