### PR TITLE
build[PPP-7015,PPP-7031]: bump activemq.version 5.19.8 -> 5.19.9 (CVE-2026-59878, CVE-2026-61487)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <pax-url-aether.version>3.0.3</pax-url-aether.version>
     <cxf.version>3.6.12</cxf.version>
 
-    <activemq.version>5.19.8</activemq.version>
+    <activemq.version>5.19.9</activemq.version>
     <byte-buddy.version>1.17.6</byte-buddy.version>
     <maven-filtering.version>3.3.1</maven-filtering.version>
     <javassist.version>3.30.2-GA</javassist.version>


### PR DESCRIPTION
## CVE fix: ActiveMQ 5.19.8 -> 5.19.9

Bumps the org-root `activemq.version` property from `5.19.8` to `5.19.9`.

| CVE | Sev / CVSS | CWE | Jira |
|---|---|---|---|
| CVE-2026-59878 | High / 7.5 | CWE-20 improper input validation (AMQP NIO frame size -> DoS) | PPP-7031 |
| CVE-2026-61487 | Medium / 6.5 | CWE-285 improper authorization (composite temp destination bypasses write ACL) | PPP-7015 |

Advisory (Apache ActiveMQ): affects Broker / All / AMQP before **5.19.9**, and 6.0.0 before 6.2.8. `5.19.9` is the minimal fix on the release line already in use, so no major/minor migration is involved.

Build: `pdia-master@11.1.0.0-370`. Xray flags `org.apache.activemq:activemq-all`, `:activemq-broker` and `:activemq-amqp` at 5.19.8, but every impact path ends at the **same single file** -- `.../plugins/pdi-jms-plugin/lib/activemq-all-5.19.8.jar` (PDI EE client, PRD EE, pentaho-server EE, pentaho-server-manual EE). The broker/amqp coordinates are the `META-INF/maven/**/pom.xml` entries **inside** that uber jar, not separately shipped artifacts.

### Why here

`<activemq.version>` in this pom is the **only** declaration of the version org-wide (searched `pentaho` + `webdetails`). Consumers reference `${activemq.version}` and define nothing locally, so there is no leaf override to remove:

- `pentaho/pdi-jms-plugin` -- `pom.xml`, `core/pom.xml`, `assemblies/plugin/pom.xml` (this is what ships the jar)
- `pentaho/pentaho-kettle` -- `plugins/streaming/impls/mqtt/pom.xml`, `activemq-kahadb-store` + `activemq-mqtt`, **test scope only**

No karaf `bundleReplacement` entries exist for activemq, so the assembly repos need no companion change.

### Risk assessment: contained

Upstream delta 5.19.8...5.19.9 is 16 commits on the same patch line; the two security fixes are `Ensure composite temp dests are handled in AuthorizationBroker (#2219)` and `Add better frame size validation for AMQP (#2167)`.

Read from the published jars rather than the release notes:

- classes 6407 -> 6409; exactly **one removed**, `store/kahadb/MessageDatabase$MessageOrderIndex$MessageOrderIterator` -- a broker-side inner-class refactor. No public client API removed.
- bytecode major 55 (Java 11) on both -> no JDK-21 concern.
- `activemq-all` carries no `Import-Package` (not an OSGi bundle) and `pdi-jms-plugin` uses no `maven-bundle-plugin` -> no Karaf wiring delta.

The whole first-party API surface is one call, `new ActiveMQConnectionFactory(brokerURL)` in `pdi-jms-plugin` `core/.../jms/Jms.java`. Every changed area is broker-side (AuthorizationBroker, AMQP acceptor, KahaDB, cursors) and unreachable from a JMS client; the `maxFrameSize` default change is in the sample `conf/activemq.xml`, not client code. No downstream-facing boundary moves.

### Verification

Test coverage for the ActiveMQ client path was added first, on the **vulnerable** 5.19.8 baseline, in pentaho/pdi-jms-plugin#113 (the existing tests mocked `ConnectionFactory` outright, so the library was never exercised). Green there before this bump.

Then, with this pom installed locally, `pdi-jms-plugin` re-resolved:

```
BEFORE  com.pentaho.di.plugins:pdi-jms-plugin-core
        \- org.apache.activemq:activemq-all:jar:5.19.8:compile
        com.pentaho.di.plugins:pdi-jms-plugin (assemblies/plugin)
        \- org.apache.activemq:activemq-all:jar:5.19.8:provided

AFTER   com.pentaho.di.plugins:pdi-jms-plugin-core
        \- org.apache.activemq:activemq-all:jar:5.19.9:compile
        com.pentaho.di.plugins:pdi-jms-plugin (assemblies/plugin)
        \- org.apache.activemq:activemq-all:jar:5.19.9:provided
```

`mvn dependency:tree -Dverbose -Dincludes=org.apache.activemq:*` shows a single path and a single coordinate -- no shaded, forked or transitive second copy of 5.19.8 survives. `pdi-jms-plugin` `core` suite on 5.19.9: **16 tests, 0 failures, 0 errors, 1 skipped**.

### Not done here

Clearance is only proven when a later `pdia-master` build is re-analyzed and both CVEs are absent. Please do not treat merge as verification.

Opened by CodeMedic. Related: pentaho/pdi-jms-plugin#113.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-370", "items": [{"cve": "CVE-2026-61487", "coordinate": "org.apache.activemq:activemq-broker"}, {"cve": "CVE-2026-61487", "coordinate": "org.apache.activemq:activemq-all"}, {"cve": "CVE-2026-59878", "coordinate": "org.apache.activemq:activemq-all"}, {"cve": "CVE-2026-59878", "coordinate": "org.apache.activemq:activemq-amqp"}]} -->
