### PR TITLE
build[PPP-7040]: bump lz4-java.version 1.10.3 -> 1.11.2 (CVE-2026-59949)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -477,7 +477,7 @@
     
     <apache-sshd.version>2.16.0</apache-sshd.version>
 
-    <lz4-java.version>1.10.3</lz4-java.version>
+    <lz4-java.version>1.11.2</lz4-java.version>
 
     <!-- poi  -->
     <poi.version>5.5.1</poi.version>


### PR DESCRIPTION
## CVE-2026-59949 -- `at.yawk.lz4:lz4-java` 1.10.3 -> 1.11.2

Jira: **PPP-7040** | Build: `pdia-master@11.1.0.0-370` | Severity: Medium (CVSS 6.5)

### What and why

`lz4-java.version` is the single org-wide definition point for this component; every declaring module in the org (`pentaho-hadoop-shims`, `pdi-plugins-ee` kinesis, `pdi-plugin-elasticsearch-rest-ee`) references `${lz4-java.version}` and none pins a literal. Bumping it here fixes every shipping path at once.

### Why 1.11.2 and not 1.11.1

The advisory for CVE-2026-59949 is fixed in 1.11.1, but Xray reports **three** findings against this coordinate on the affected build, and 1.11.1 clears only one. Version ladder from Xray's component index:

| version | open Xray issues |
|---|---|
| 1.10.3 (current) | 3 -- XRAY-1033044 (CVE-2026-59949), XRAY-1046408, XRAY-1046409 |
| 1.11.0 | 3 |
| 1.11.1 | 2 (XRAY-1046408, XRAY-1046409 remain) |
| **1.11.2** | **0** |

1.11.2 is upstream's security release for `GHSA-6cx8-rjf8-pr8g` + `GHSA-4v53-57pg-c464` -- the unvalidated length-header allocations in `LZ4BlockInputStream` / `LZ4DecompressorWithLength` -- which are exactly those two remaining issues. It is a patch release on the same 1.11.x line.

### Upgrade risk

Delta 1.10.3 -> 1.11.2 verified from the published jars, not the release notes:

| | 1.10.3 | 1.11.2 |
|---|---|---|
| public classes | 57 | 60 |
| removed | -- | **none** |
| added | -- | `LZ4JNIFastResetCompressor`, `LZ4JNIHCFastResetCompressor`, `AbstractLZ4JNIFastResetCompressor` |
| bytecode major | 51 (Java 7) | 51 (Java 7) |
| OSGi `Import-Package` | `java.*` only | unchanged |

Purely additive API plus stricter validation of caller-supplied ranges and attacker-controlled length headers. No first-party code calls `net.jpountz` for this coordinate; it is reached only as a Hadoop / ORC / Parquet / Kafka codec behind unchanged first-party APIs.

### Verification

Property resolution and the resolved tree were checked against a locally installed copy of this branch:

```
# BEFORE
[INFO] \- at.yawk.lz4:lz4-java:jar:1.10.3:compile
# AFTER
[INFO] \- at.yawk.lz4:lz4-java:jar:1.11.2:compile
```

Confirmed at 1.11.2 in every module that ships or tests the component:

| module | scope | after |
|---|---|---|
| `pentaho-hadoop-shims` `common-base` | test | 1.11.2 |
| `pentaho-hadoop-shims` `shims/cdpdc71/driver` | compile | 1.11.2 |
| `pentaho-hadoop-shims` `shims/emr770/driver` | compile | 1.11.2 |
| `pentaho-hadoop-shims` `shims/apachevanilla/driver` | compile | 1.11.2 |
| `pdi-plugins-ee` `kinesis/impl` | compile | 1.11.2 |

`shims/apachevanilla/driver` carried a local `lz4-java.version` override that shadowed this property; it is removed in the companion PR **pentaho/pentaho-hadoop-shims#(see below)**, which also adds regression guards over the affected LZ4 code paths (RED on 1.10.3, green on 1.11.2). That PR is blocked by this one.

Clearance is confirmed only when a later `pdia-master` build is re-analysed and the CVE is absent -- not by this PR being merged.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-370", "items": [{"cve": "CVE-2026-59949", "coordinate": "at.yawk.lz4:lz4-java"}, {"cve": "XRAY-3421937", "coordinate": "at.yawk.lz4:lz4-java"}, {"cve": "XRAY-1012217", "coordinate": "at.yawk.lz4:lz4-java"}]} -->
