### PR TITLE
build[PPP-6912]: allow Bouncy Castle minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,12 @@ updates:
       interval: weekly
     allow:
       - dependency-name: io.netty:*
+      - dependency-name: org.bouncycastle:*
     ignore:
-      - dependency-name: "*"
+      - dependency-name: io.netty:*
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+      - dependency-name: org.bouncycastle:*
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## Summary
- Allow Dependabot to open minor and patch updates for `org.bouncycastle:*`.
- Retain Netty as patch-only and block Bouncy Castle major updates.

## Validation
- Parsed and asserted the Dependabot Maven update policy.
- Ran `git diff --check`.

Bouncy Castle dependency management is already centralized in the parent POM; this PR only adjusts Dependabot policy.