### PR TITLE
build: configure Maven registry for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,19 @@
 version: 2
+registries:
+  pnt-mvn:
+    type: maven-repository
+    url: https://repo.pentaho.com/artifactory/pnt-mvn
+    username: ${{ secrets.PENTAHO_CICD_ONE_USER }}
+    password: ${{ secrets.PENTAHO_CICD_ONE_KEY }}
+    replaces-base: true
 updates:
   - package-ecosystem: maven
     directory: /
+    registries:
+      - pnt-mvn
     schedule:
       interval: weekly
+    open-pull-requests-limit: 1
     allow:
       - dependency-name: io.netty:*
       - dependency-name: org.bouncycastle:*


### PR DESCRIPTION
## Summary

- configure Dependabot to authenticate against the Pentaho Maven registry
- resolve Maven dependencies through `pnt-mvn`
- limit Dependabot version-update pull requests to one open pull request

## Validation

- parsed the Dependabot YAML and asserted the `pnt-mvn` registry association, Maven registry type, base replacement setting, and pull request limit
- ran `git diff --check`