### PR TITLE
[PPP-7134][PPP-7071] Bump httpclient5 5.4.4 -> 5.6.4 for CVE-2026-71290 (Critical) + CVE-2026-64607

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
     <jetty-server.version>12.0.37</jetty-server.version>
     <jetty-hadoop.version>9.4.57.v20241219</jetty-hadoop.version>
     <httpclient.version>4.5.14</httpclient.version>
-    <httpclient5.version>5.6.3</httpclient5.version>
+    <httpclient5.version>5.6.4</httpclient5.version>
     <hadoop-shaded-protobuf_3_25.version>1.3.0</hadoop-shaded-protobuf_3_25.version>
     <dnsjava.version>3.6.0</dnsjava.version>
     <httpcore.version>4.4.11</httpcore.version>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
     <jetty-server.version>12.0.37</jetty-server.version>
     <jetty-hadoop.version>9.4.57.v20241219</jetty-hadoop.version>
     <httpclient.version>4.5.14</httpclient.version>
-    <httpclient5.version>5.4.4</httpclient5.version>
+    <httpclient5.version>5.6.3</httpclient5.version>
     <hadoop-shaded-protobuf_3_25.version>1.3.0</hadoop-shaded-protobuf_3_25.version>
     <dnsjava.version>3.6.0</dnsjava.version>
     <httpcore.version>4.4.11</httpcore.version>


### PR DESCRIPTION
## CVE-2026-71290 (Critical) + CVE-2026-64607 (Medium) -- Apache HttpClient 5

> **Update 2026-08-19 -- the target moved from 5.6.3 to 5.6.4.** This PR originally bumped `httpclient5.version` to **5.6.3** to clear CVE-2026-64607. While it was awaiting review a second, **Critical** advisory landed on the same component -- **CVE-2026-71290** -- which **5.6.3 does not fix**. Rather than open a second PR editing the same property, the target is raised here to **5.6.4**, the minimal version that clears **both**. The original 5.6.3 rationale is preserved below and still applies.

| | CVE-2026-71290 | CVE-2026-64607 |
|---|---|---|
| **Severity** | **Critical, CVSS 9.1** | Medium, CVSS 5.3 |
| **CWE** | CWE-295 improper certificate validation | CWE-772 missing release of resource |
| **Affected** | 5.4 .. **5.6.3** | 5.0-alpha1 .. 5.6.2 |
| **Fixed in** | **5.6.4** | 5.6.3 |
| **i/o model** | **async only** | classic only |
| **Jira** | PPP-7134 | PPP-7071 |
| **Xray issue** | `XRAY-1049726` | `XRAY-1040040` |

**Target: `httpclient5.version` 5.4.4 -> 5.6.4.** Build `pdia-master@11.1.0.0-378`.

### CVE-2026-71290 -- why 5.6.3 was not enough

`HostnameVerificationPolicy.BUILTIN` has **no effect** on the async HttpClient, so an attacker able to intercept traffic can impersonate a server by presenting a valid certificate issued for a *different* domain. The classic client is unaffected. The Apache advisory states plainly: *"Affected users are recommended to upgrade to at least version 5.6.4, which fixes the issue."*

An Xray component ladder independently agrees:

| version | Xray issues |
|---|---|
| 5.6.2 | 2 (both CVEs) |
| **5.6.3** | **1 -- CVE-2026-71290 still present** |
| **5.6.4** | **0** |

Xray and the CNA agree, so this is a genuine fixed release rather than a range-model artefact.

### Proof: reproduced, then proven gone

A TLS server presents a self-signed certificate valid **only** for `wrong.example.com`. An **async** `CloseableHttpAsyncClient` configured with `HostnameVerificationPolicy.BUILTIN` connects to `localhost`. An all-trusting `X509TrustManager` is installed deliberately, so *hostname verification is the only thing that can reject the peer*. Identical classpath in every run except the httpclient5 jar.

| httpclient5 | result | verdict |
|---|---|---|
| **5.4.4** (what we ship today) | request COMPLETED, HTTP 200 | **VULNERABLE** |
| **5.5** (ships in the vendor path) | request COMPLETED, HTTP 200 | **VULNERABLE** |
| **5.6.3** (this PR's original target) | request COMPLETED, HTTP 200 | **VULNERABLE** |
| **5.6.4** (new target) | `SSLHandshakeException: (certificate_unknown) No subject alternative DNS name matching localhost found` | **FIXED** |

A certificate for the wrong domain was silently accepted on 5.6.3 and is correctly rejected on 5.6.4.

### Blast radius of the extra 5.6.3 -> 5.6.4 step: nil

Measured from the JARs, not inferred from semver:

- **Class set identical** -- 595 classes in both, 0 added, 0 removed.
- **Public API diff empty** -- `javap -public` across all 595 classes yields byte-identical 4987-line dumps. Zero signature changes.
- **Exactly 3 classes changed bytecode**: `impl/auth/BearerScheme` (+ its `$State`) and `ssl/AbstractClientTlsStrategy` -- the latter being the fix itself (the `BUILTIN`/`BOTH` policy check now sits on a path the async client actually reaches). No member signatures changed.
- **No companion bump** -- `httpclient5-parent:5.6.4` pins `httpcore.version=5.4.3`, identical to 5.6.3's and to our existing `httpcore5.version`. No new transitives.

This step is strictly lower-risk than the 5.4.4 -> 5.6.3 change already under review here.

---

## Original rationale (5.4.4 -> 5.6.3), unchanged and still applicable

### CVE-2026-64607

HttpClient based on the **classic** i/o model fails to release the underlying connection back to the connection manager when it encounters an invalid or unsupported `Content-Encoding` response header. A remote peer can therefore exhaust the connection pool. The async i/o model is unaffected.

### Why this one property is the whole fix

`httpclient5.version` in this root `pentaho-parent-pom`, backed by its `dependencyManagement` entry, is the single declaration point. An org-wide code search (re-run 2026-08-19) confirms every affected consumer declares `httpclient5` **version-less** and inherits it:

| Repo | Manifest | Ships into |
|---|---|---|
| `pentaho-kettle` | `core/pom.xml` | `data-integration/lib` (pdi-ce, pdi-ee-client) |
| `pentaho-platform` | `extensions/pom.xml` | `pentaho.war` (server ce/ee, manual ce/ee) |
| `pentaho-platform-ee` | `assemblies/pentaho-war-ee/pom.xml` | `pentaho.war` (ee) |
| `pentaho-reporting` | root depMgmt + `libraries/libpensol` | `report-designer/lib` (prd-ce/ee) |
| `big-data-plugin` | `assemblies/pmr-libraries/pom.xml` | `pentaho-mapreduce-libraries.zip` |
| `pentaho-big-data-ee` | `assemblies/pmr-ee-libraries/pom.xml` | big-data-ee plugin (apachevanilla/emr/cdp/dataproc) |

That covers all 15 first-party impact paths on both tickets (server, PDI, PRD, PSW, PME, PAD, big-data). `pentaho-reporting`'s root POM *references* `${httpclient5.version}` but does not define it, so it is inherited -- there is no leaf shadow to chase.

**Out of scope** (own version property / different build): `pdi-openlineage-plugin-ee`, `pentaho-mcp-ai` (5.3.1), `pdc-workers-java` (5.2.1), `fusion-secrets-management`, `connection-management-service`. `pentaho-kettle/plugins/repo-vfs/repo-vfs-ws` pins a literal `5.5` but at `<scope>test</scope>`, so it never ships.

**Not covered by this PR:** the `httpclient5-5.5.jar` impact paths inside `enterprise-local-license-server/server/flexnetls.jar` (`BOOT-INF/lib/`) are Revenera's vendor fat jar. There is no first-party declaration to bump, so that residue survives this fix and needs a vendor update.

### Containment

- **No first-party source calls httpclient5.** An org-wide search for `org.apache.hc.client5` returns hits only in the out-of-scope repos above; on this parent chain it is a pure runtime jar reached transitively (e.g. commons-vfs2's optional HTTP provider). Nothing to adapt.
- The entire non-`impl` public API of 5.4.4 is still present in 5.6.4; the only non-`impl` removals across the whole 5.4.4 -> 5.6.x range are two constructors of the package-private `HttpRFC7578Multipart`, unreachable by consumers.
- **Java 8 bytecode** target -- safe on the JDK17 train.
- 5.6.x's new `commons-compress` / `zstd-jni` / `brotli4j` dependencies are all `<optional>true</optional>` and do not enter the resolved tree.

### Dependency-tree proof

This repo is pom-only, so verification uses the established probe-module recipe: a throwaway module inheriting `org.pentaho:pentaho-parent-pom`, resolved against the locally installed parent before and after.

**Before** (master)
```
+- org.apache.httpcomponents.client5:httpclient5:jar:5.4.4:compile   <-- VULNERABLE to both
|  +- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:compile
|  \- org.slf4j:slf4j-api:jar:2.0.12:compile
\- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:compile
```
**Intermediate** (this branch before today's commit)
```
+- org.apache.httpcomponents.client5:httpclient5:jar:5.6.3:compile   <-- still VULNERABLE to CVE-2026-71290
```
**After** (this branch now)
```
+- org.apache.httpcomponents.client5:httpclient5:jar:5.6.4:compile   <-- FIXED, both CVEs
|  +- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:compile
|  \- org.slf4j:slf4j-api:jar:2.0.12:compile
\- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:compile
```
`httpclient5:5.4.4` (and `5.6.3`) is gone on every path, and nothing else moved.

### The 64607 leak, reproduced and proven gone (from the original run)

Harness: a local `HttpServer` returning `Content-Encoding: banana`, a `PoolingHttpClientConnectionManager` capped at 2 connections, three sequential requests.

| | 5.4.4 (vulnerable) | fixed line |
|---|---|---|
| request 0 | `ClientProtocolException` -- pool `leased: 1` | `ClientProtocolException` -- pool `leased: 0` |
| request 1 | `ClientProtocolException` -- pool `leased: 2` | `leased: 0` |
| request 2 | **`ConnectionRequestTimeoutException`** -- pool exhausted | `leased: 0` |
| verdict | **LEAKED** | **NO LEAK** |

## What a reviewer should weigh

1. **CVE-2026-71290 is the one that matters.** It is Critical (9.1) and defeats TLS server authentication for any async-client user relying on `HostnameVerificationPolicy.BUILTIN`. It is also the reason this PR must not be merged at 5.6.3.
2. **CVE-2026-64607's exploitability in our default configuration is limited** -- the leak requires the non-default strict decompression mode (`ContentCompressionExec(false)`); with the stock builder 5.4.4 silently passes an unknown encoding through and does not leak.
3. **There is a real default-behaviour change in 5.6.x.** The `ignoreUnknown` boolean no longer exists (the field is now `maxCodecListLen`, an int), so an unsupported `Content-Encoding` now **always** raises `ClientProtocolException`, where 5.4.4 passed the body through unchanged. No first-party code calls httpclient5, so this can only surface through a transitive consumer talking to a server that emits an exotic encoding -- but it is a genuine semantic change and worth a human eye.
4. **The branch name still says `5.6.3`** -- cosmetic only; the branch was kept so this PR's existing review history is preserved rather than forking a duplicate PR against the same line.

## Verification

Clearance is confirmed when a subsequent `pdia-master` build is re-analyzed and **both** CVEs are absent -- not at merge time. Not auto-merged; this repo's owners review.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-378", "items": [{"cve": "CVE-2026-71290", "coordinate": "org.apache.httpcomponents.client5:httpclient5"}, {"cve": "CVE-2026-64607", "coordinate": "org.apache.httpcomponents.client5:httpclient5"}]} -->
