### PR TITLE
build[PPP-7120]: Move dependency management of pentaho-shaded-netty to maven parent pom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
     open-pull-requests-limit: 1
     allow:
       - dependency-name: io.netty:*
+      - dependency-name: org.pentaho.hadoop:pentaho-shaded-netty
       - dependency-name: org.bouncycastle:*
     ignore:
       - dependency-name: io.netty:*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,19 @@
 version: 2
+registries:
+  pnt-mvn:
+    type: maven-repository
+    url: https://repo.pentaho.com/artifactory/pnt-mvn
+    username: ${{ secrets.PENTAHO_CICD_ONE_USER }}
+    password: ${{ secrets.PENTAHO_CICD_ONE_KEY }}
+    replaces-base: true
 updates:
   - package-ecosystem: maven
     directory: /
+    registries:
+      - pnt-mvn
     schedule:
       interval: weekly
+    open-pull-requests-limit: 1
     allow:
       - dependency-name: io.netty:*
       - dependency-name: org.bouncycastle:*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ registries:
     url: https://repo.pentaho.com/artifactory/pnt-mvn
     username: ${{ secrets.PENTAHO_CICD_ONE_USER }}
     password: ${{ secrets.PENTAHO_CICD_ONE_KEY }}
-    replaces-base: true
 updates:
   - package-ecosystem: maven
     directory: /

--- a/pom.xml
+++ b/pom.xml
@@ -468,6 +468,7 @@
     <mina-core.version>2.2.8</mina-core.version>
     <saxon-he.version>12.7</saxon-he.version>
     <netty.version>4.1.137.Final</netty.version>
+    <pentaho-shaded-netty.version>4.1.137.Final-pentaho-1</pentaho-shaded-netty.version>
     <netty-tcnative.version>2.0.81.Final</netty-tcnative.version>
     <xmlresolver.version>6.0.17</xmlresolver.version>
     <xmlunit.version>1.6</xmlunit.version>
@@ -552,6 +553,11 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.pentaho.hadoop</groupId>
+        <artifactId>pentaho-shaded-netty</artifactId>
+        <version>${pentaho-shaded-netty.version}</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
## Summary
- Manage `org.pentaho.hadoop:pentaho-shaded-netty` centrally at its full published release version.
- Extend the existing Maven Dependabot job to monitor the shaded artifact.
- Remove the need for consumer repositories to derive a shaded version from the upstream Netty version.

## Validation
- `mvn --batch-mode --offline -nsu install -DskipTests`
- Verified `pentaho-hadoop-shims` validates against the installed parent reactor.