### PR TITLE
fix[PPP-6766]: bump fasterxml-jackson to 2.18.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,10 +216,10 @@
     <antlr4-runtime.version>4.13.0</antlr4-runtime.version>
     <webservices.version>4.0.4</webservices.version>
     <jaxb-runtime.version>4.0.5</jaxb-runtime.version>
-    <fasterxml-jackson.version>2.18.8</fasterxml-jackson.version>
+    <fasterxml-jackson.version>2.18.9</fasterxml-jackson.version>
     <hv-jackson-dataformat.version>2.14.1</hv-jackson-dataformat.version>
-    <fasterxml-jackson-databind.version>2.18.8</fasterxml-jackson-databind.version>
-    <fasterxml-jackson.non-osgi.version>2.18.8</fasterxml-jackson.non-osgi.version>
+    <fasterxml-jackson-databind.version>2.18.9</fasterxml-jackson-databind.version>
+    <fasterxml-jackson.non-osgi.version>2.18.9</fasterxml-jackson.non-osgi.version>
     <dom4j.version>2.1.4</dom4j.version>
     <jaxen.version>1.1.6</jaxen.version>
     <xstream.version>1.4.21</xstream.version>


### PR DESCRIPTION
Ideally we have to stop the triplicated versions for jackson in the future