### PR TITLE
build[PPP-6926]: Bump org.postgresql:postgresql 42.7.11 -> 42.7.12 (CVE-2026-54291)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <log4j.version>2.25.5</log4j.version>
     <log4j-slf4j2.version>2.25.5</log4j-slf4j2.version>
     <commons-logging.version>1.3.5</commons-logging.version>
-    <postgresql.version>42.7.11</postgresql.version>
+    <postgresql.version>42.7.12</postgresql.version>
     <jline.version>3.30.15</jline.version>
 
     <jsch.version>0.2.26</jsch.version>


### PR DESCRIPTION
## CVE-2026-54291 -- `org.postgresql:postgresql` 42.7.11 -> 42.7.12

| | |
|---|---|
| **CVE** | CVE-2026-54291 |
| **Aliases** | GHSA-j92g-9f8w-j867, BIT-postgresql-jdbc-driver-2026-54291 |
| **Severity** | Medium, CVSS 5.9 -- CWE-636, CWE-757 |
| **Component** | `org.postgresql:postgresql` @ 42.7.11 (maven) |
| **Target** | **42.7.12** -- the advisory's fixed version and the minimal one on the 42.7.x line |
| **Build** | `pdia-master@11.1.0.0-378` |
| **Jira** | [PPP-6926](https://pentaho-eng.atlassian.net/browse/PPP-6926) |
| **Advisory** | https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-j92g-9f8w-j867 |

### The vulnerability

In pgJDBC **42.7.4 through 42.7.11**, a `channelBinding=require` connection can be **silently downgraded** from `SCRAM-SHA-256-PLUS` (with channel binding) to plain `SCRAM-SHA-256` (without it), losing exactly the man-in-the-middle protection that setting is meant to guarantee. An attacker able to intercept the TLS connection triggers it with a certificate whose signature algorithm has no `tls-server-end-point` channel-binding hash -- Ed25519, Ed448, post-quantum algorithms.

Two defects combine:

1. The bundled `com.ongres.scram:scram-client` returns an **empty byte array** instead of failing when it cannot derive the binding hash (upstream library advisory GHSA-p9jg-fcr6-3mhf).
2. `ScramAuthenticator` checks only that the server *advertised* a `-PLUS` mechanism. It rejects neither the empty binding nor a negotiated mechanism that does not actually use channel binding.

Only `channelBinding=require` is affected. Under the default `prefer`, and under `allow`/`disable`, falling back to plain SCRAM is documented behaviour. Releases before 42.7.4 predate channel-binding support and are unaffected.

### Why this one line is the whole fix

Every consumer that puts this driver into a shipped `pdia-master` artifact declares `org.postgresql:postgresql` **without a version element**, inheriting this `dependencyManagement` entry:

| repo | manifest | impact path it feeds |
|---|---|---|
| `pentaho/pentaho-platform` | `assemblies/pentaho-server/pom.xml`, `extensions/pom.xml` | `pentaho-server-{ce,ee}` -> `tomcat/lib/` |
| `pentaho/pentaho-reporting` | `assemblies/prd-ce/pom.xml` | `prd-ce` -> `report-designer/lib{,/jdbc}/` |
| `pentaho/pentaho-reportdesigner-ee` | `assemblies/pom.xml` | `prd-ee` -> `report-designer/lib{,/jdbc}/` |
| `pentaho/big-data-plugin` | `assemblies/pmr-libraries/pom.xml` | `pentaho-mapreduce-libraries.zip/lib/` |
| `pentaho/pentaho-big-data-ee` | `assemblies/pmr-ee-libraries/pom.xml` | `pentaho-big-data-ee-plugin` (apachevanilla, cdp, dataproc, emr) |
| `pentaho/pentaho-kettle` | `engine/pom.xml` | `pdi-{ce,ee}-client` -> `data-integration/lib/` |
| `pentaho/mondrian` | `assemblies/psw-ce/pom.xml` | (test scope) |
| `pentaho/pentaho-scheduler-plugin-ee` | `pom.xml`, `core/pom.xml` | server plugin |

`pme-{ce,ee}` (`metadata-editor/libext/pentaho/`) carries no declaration of its own either -- it inherits too. So **one line here clears all 14 impact paths in the ticket**, and no leaf override needs removing because none exists.

Checked and deliberately **not** touched (no `pdia-master` impact path -- they will surface on their own builds): `pdi-openlineage-plugin-ee` (own `42.7.8`), `cssapi` (`42.3.3`), `pdc-workers-java` (`42.7.3`), `pdc-ops-service` / `pdc-metadata-model` (Gradle `postgresqlForcedVersion=42.7.11`, PDC product).

### Risk assessment -- contained

Containment was proved from the **published artifacts**, not from the version number. A full entry-by-entry SHA-256 diff of `postgresql-42.7.11.jar` vs `postgresql-42.7.12.jar`:

- **553 entries in both; 0 added, 0 removed.** No public API appears or disappears, so nothing a consumer binds to can break.
- **12 entries differ**, and 11 are version-string carriers: `META-INF/MANIFEST.MF`, `util/DriverInfo`, `Driver`, `PgConnection`, `PgDatabaseMetaData`, `PGSimpleDataSource`, `PGPoolingDataSource`, `PGConnectionPoolDataSource`, `PGXADataSource`, `osgi/PGBundleActivator`, `util/PGJDBCMain`.
- The **only** substantive change is `org/postgresql/core/v3/ScramAuthenticator.class` -- precisely the class the advisory names.

Upstream calls this release "v42.7.12: security" and the notes describe nothing but this CVE.

**No transitive surface.** The published `postgresql-42.7.12.pom` declares **no dependencies at all** -- scram is shaded into the jar under `org/postgresql/shaded/com/ongres/scram/`. No BOM/family-coherence question, no companion-pin to realign.

**Behaviour change, in full.** A `channelBinding=require` connection that previously downgraded silently now **fails** -- which is the fix, and the behaviour that setting always promised. No first-party repo sets that property: an org-wide search for `channelBinding` returns 4 hits, all in `pentaho/smbj` and all the unrelated SMB/NTLM `MsvAvChannelBindings` AV-pair. So no first-party connection changes behaviour. A *customer* who has set `channelBinding=require` against a server with an Ed25519/Ed448/post-quantum certificate will start seeing connection failures instead of an insecure success -- that may deserve a release note.

**One thing reviewers should know:** `org/postgresql/shaded/.../ScramClient.class` is **byte-identical** between the two jars -- scram-client is still 3.2 (per `META-INF/licenses/`). pgJDBC fixed its own half of the pair rather than re-shading the library. Breaking either half breaks the attack chain and this clears CVE-2026-54291, but the underlying library advisory GHSA-p9jg-fcr6-3mhf is not itself re-shaded by this release.

### Verification

`maven-parent-poms` is a pure POM aggregator -- no source, no test sources, no test phase -- so there is no suite to harden on the vulnerable baseline. The equivalent baseline, captured **before** the edit, is a resolution probe: a throwaway module inheriting `org.pentaho:pentaho-parent-pom:11.1.0.0-SNAPSHOT` and declaring `org.postgresql:postgresql` **without a version element**, i.e. exactly the shape every shipping consumer uses. `mvn -N install` the parent, then `dependency:tree`:

```
BEFORE (parent at HEAD e3da7bb, unmodified)
  \- org.postgresql:postgresql:jar:42.7.11:compile

AFTER (parent with this one-line bump)
  Downloaded: .../pnt-mvn/org/postgresql/postgresql/42.7.12/postgresql-42.7.12.jar (1.1 MB)
  \- org.postgresql:postgresql:jar:42.7.12:compile
```

Supporting checks:

- **Xray ladder** -- `42.7.11` -> 1 issue (`XRAY-1032011` / CVE-2026-54291); `42.7.12` -> **0 issues**. Cross-checked against the vendor advisory and upstream release notes, which independently name 42.7.12 as the fix, so this is not a laddered guess.
- **Resolves through the proxy** -- `GET artifactory/pnt-mvn/org/postgresql/postgresql/42.7.12/postgresql-42.7.12.pom` returns 200, and the AFTER build downloaded the jar from `pnt-mvn` for real.
- **No shadowing** -- grepping this repo for references to the `postgresql.version` property returns only the single `dependencyManagement` entry, and no literal `42.7.x` remains anywhere.
- **No non-pom pin** -- org-wide search of karaf features, assembly descriptors and other XML found only JDBC URLs, driver class names and docs. `webdetails`: no postgresql version declaration at all.

### Not done here

Per CodeMedic policy this PR is **not** auto-merged, and the CVE is not considered fixed until a **later** `pdia-master` build is re-analyzed and CVE-2026-54291 is absent. Merging is the human decision this PR asks for.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-378", "items": [{"cve": "CVE-2026-54291", "coordinate": "org.postgresql:postgresql"}]} -->


[PPP-6926]: https://pentaho-eng.atlassian.net/browse/PPP-6926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ