### PR TITLE
fix: backport of PPP-6304 Upgrade avro to non vulnerable version [SP-7553]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
     <kafka-clients.version>4.1.2</kafka-clients.version>
     <paho.version>1.2.2</paho.version>
     <h2.version>2.2.224</h2.version>
-    <org.apache.avro.version>1.12.0</org.apache.avro.version>
+    <org.apache.avro.version>1.12.1</org.apache.avro.version>
     <!-- jdk14 and jdk15on versions not to be used; supports older third-party pom files in build -->
     <bcprov-jdk14.version>1.72</bcprov-jdk14.version>
     <bcprov-jdk15on.version>1.65</bcprov-jdk15on.version>


### PR DESCRIPTION
cherry-pick of: [f786cd7](https://github.com/pentaho/maven-parent-poms/commit/f786cd794b8d2621d7c701cc836bf6fec2c8e658)

original PR: https://github.com/pentaho/maven-parent-poms/pull/894