### PR TITLE
build[PPP-6944]: Bump spring-ws-core 4.0.12 -> 4.1.4 (CVE-2026-40998, CVE-2026-40999)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
     <spring-boot.version>2.4.2</spring-boot.version>
     <spring-security-kerberos.version>1.0.1.RELEASE</spring-security-kerberos.version>
     <karaf-springframework-override.version>4.1.9.RELEASE_1</karaf-springframework-override.version>
-    <spring-ws-core.version>4.0.12</spring-ws-core.version>
+    <spring-ws-core.version>4.1.4</spring-ws-core.version>
     <xercesImpl.version>2.12.2</xercesImpl.version>
     <xml-apis.version>1.4.01</xml-apis.version>
     <spring-data-jpa.version>3.5.13</spring-data-jpa.version>


### PR DESCRIPTION
## CVE-2026-40998 (High, CVSS 8.2, CWE-611 XXE) and CVE-2026-40999 (High, CVSS 8.6, CWE-918 SSRF)

Bumps the org-wide `spring-ws-core.version` from **4.0.12** to **4.1.4**.

- Advisories: Spring Web Services 5.0.0-5.0.1, **4.1.0-4.1.3**, **4.0.0-4.0.18**, 3.1.0-3.1.8 are affected.
  - `CVE-2026-40998` -- `Jaxp13XPathTemplate` evaluated XPath over `StreamSource`/`SAXSource` using the JDK's default `DocumentBuilderFactory` instead of Spring's hardened parser, so external entities in attacker-supplied XML were resolved (XXE).
  - `CVE-2026-40999` -- with WS-Addressing and non-anonymous `ReplyTo`/`FaultTo`, outbound connections were made to destinations taken straight from request headers without validation (SSRF).
- Jira: PPP-6944, PPP-6980 (component-scope). PPP-6619 / PPP-6639 are the license-server-scope siblings and are **not** fixed by this PR -- see below.
- Build: `pdia-master@11.1.0.0-381`.

### Why 4.1.4 and not a 4.0.x patch

The advisory (and JFrog's "Fix Versions" field) names **4.0.19** as a fixed release on the 4.0 line. **4.0.19 does not exist.** The published `maven-metadata.xml` for `org.springframework.ws:spring-ws-core` ends the 4.0 line at **4.0.17** and continues at 4.1.0; both `4.0.18` and `4.0.19` return `404` from the Artifactory proxy. So there is no fixed release on the 4.0 line at all, and 4.1.4 is the lowest published version that clears both CVEs.

| version | Xray `summary/component` | exists |
|---|---|---|
| 4.0.12 (current) | CVE-2026-40998, CVE-2026-40999 | yes |
| 4.0.17 (highest 4.0.x published) | CVE-2026-40998, CVE-2026-40999 | yes |
| 4.0.18 / 4.0.19 | -- | **no (404)** |
| 4.1.0 / 4.1.3 | CVE-2026-40998, CVE-2026-40999 | yes |
| **4.1.4** | **none** | yes |

### Blast radius -- one consumer, and it never calls the library

`spring-ws-core` is declared in exactly one first-party place: `pentaho/pdi-scheduler-plugin` `core/pom.xml`, version-less by `${spring-ws-core.version}`. There is no leaf override anywhere in `pentaho`/`webdetails`, so this one line covers every impact path.

4.1.x **removes 20 classes** (the deprecated `Abstract*PayloadEndpoint` hierarchy, the `*MethodEndpointAdapter` family, `Marshalling`/`XPathEndpointsBeanDefinitionParser`, `CommonsHttpConnection`/`CommonsHttpMessageSender`). None of them are reachable here:

- org-wide code search for `org.springframework.ws` in first-party Java: **0 hits** (`pdi-scheduler-plugin`'s own web-service client uses `jakarta.xml.ws`, not Spring WS);
- a bytecode scan of all 23 jars that ship in `data-integration/plugins/scheduler-plugin/lib/` for the string `org/springframework/ws/`: **0 referencing jars, 0 references to any removed class**.

`spring-xml` is 57 -> 57 classes, zero removals. Spring WS 4.1.x targets Spring Framework 6.2.x and the org baseline is already `spring.version=6.2.19`.

One deliberate transitive side effect: `spring-oxm` moves **6.1.18 -> 6.2.19** (4.1.4 aligns spring-oxm with Spring 6.2). Both versions are clean in Xray, and it puts that jar on the same 6.2.19 line as the other eight Spring jars in the same `lib/`. Shipped jar count is unchanged at 23.

### Proof

The XXE is reproduced and then observed to be fixed -- this is not a "tests passed" claim:

```
Jaxp13XPathTemplate().evaluateAsString("/payload/data",
    new StreamSource(<!DOCTYPE payload [<!ENTITY xxe SYSTEM "file:...">]> ... &xxe; ...))

4.0.12 -> returns the file contents          (XXE fires)
4.1.4  -> XPathException: DOCTYPE is disallowed when the feature
          "http://apache.org/xml/features/disallow-doctype-decl" set to true
```

A matching regression guard (`SpringWsXPathXxeSecurityTest`, 6 tests) is added in pentaho/pdi-scheduler-plugin; it fails on 4.0.12 and passes on 4.1.4.

**Re-resolved dependency tree** (`mvn -nsu dependency:tree` on `pdi-scheduler-plugin/core` against this pom installed locally):

```
BEFORE  scheduler-plugin-core
        \- org.springframework.ws:spring-ws-core:jar:4.0.12:compile
           +- org.springframework.ws:spring-xml:jar:4.0.12:compile

AFTER   scheduler-plugin-core
        \- org.springframework.ws:spring-ws-core:jar:4.1.4:compile
           +- org.springframework.ws:spring-xml:jar:4.1.4:compile
```

Packaging diff of the folder that actually ships (clean rebuild of `assemblies/plugin`):
`spring-ws-core-4.0.12.jar` + `spring-xml-4.0.12.jar` -> `spring-ws-core-4.1.4.jar` + `spring-xml-4.1.4.jar`.
No 4.0.x remains on any path. `pdi-scheduler-plugin` `core` test suite: **117 tests, 0 failures**.

### Not covered by this PR

The same CVEs also hit `spring-ws-core` **4.1.0** inside `enterprise-local-license-server/server/flexnetls.jar` (`BOOT-INF/lib/spring-ws-core-4.1.0.jar`, confirmed by downloading and listing the shipped artifact). That is Revenera's FlexNet License Server, a vendor Spring Boot 3.5.3 fat jar with no first-party fix point -- tracked separately, see the linked CodeMedic issue.

---

CodeMedic tracking: pentaho/CodeMedic (registry issue linked below). Do not merge on my behalf -- this needs the repo owners' review.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-381", "items": [{"cve": "CVE-2026-40998", "coordinate": "org.springframework.ws:spring-ws-core"}, {"cve": "CVE-2026-40999", "coordinate": "org.springframework.ws:spring-ws-core"}, {"cve": "XRAY-1001933", "coordinate": "org.springframework.ws:spring-ws-core"}, {"cve": "XRAY-1003381", "coordinate": "org.springframework.ws:spring-ws-core"}]} -->
