### PR TITLE
fix[BACKLOG-50612]: update Docker pull registry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
     <pentaho.private.release.repo />
     <pentaho.private.snapshot.repo />
 
-    <pentaho.docker.pull.host>repo.orl.eng.hitachivantara.com/pnt-docker/</pentaho.docker.pull.host>
+    <pentaho.docker.pull.host>repo.eng.pentaho.com/pnt-docker</pentaho.docker.pull.host>
     <!-- No default docker push repository, it must be defined at build-time -->
     <pentaho.docker.push.host>${pentaho.docker.public.push.host}</pentaho.docker.push.host>
 


### PR DESCRIPTION
## Summary
- update the inherited Docker pull registry from the TLS-invalid `repo.orl.eng.hitachivantara.com` endpoint to `repo.eng.pentaho.com/pnt-docker`
- normalize the host without a trailing slash, matching CI overrides; consumers provide their own repository-path separator

## Validation
- `mvn --batch-mode -DskipTests install`
- Generated Mondrian effective POMs using both this parent snapshot and the CI-style `-Dpentaho.docker.pull.host=repo.eng.pentaho.com/pnt-docker` override resolve MySQL to `repo.eng.pentaho.com/pnt-docker/mysql:8.3.0`.
- `docker pull repo.eng.pentaho.com/pnt-docker/mysql:8.3.0` succeeds.