### PR TITLE
fix[PPP-7161]: bump fasterxml-jackson to 2.18.10 (CVE-2026-68497, XRAY-1059208)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,10 +216,10 @@
     <antlr4-runtime.version>4.13.0</antlr4-runtime.version>
     <webservices.version>4.0.4</webservices.version>
     <jaxb-runtime.version>4.0.5</jaxb-runtime.version>
-    <fasterxml-jackson.version>2.18.9</fasterxml-jackson.version>
+    <fasterxml-jackson.version>2.18.10</fasterxml-jackson.version>
     <hv-jackson-dataformat.version>2.14.1</hv-jackson-dataformat.version>
-    <fasterxml-jackson-databind.version>2.18.9</fasterxml-jackson-databind.version>
-    <fasterxml-jackson.non-osgi.version>2.18.9</fasterxml-jackson.non-osgi.version>
+    <fasterxml-jackson-databind.version>2.18.10</fasterxml-jackson-databind.version>
+    <fasterxml-jackson.non-osgi.version>2.18.10</fasterxml-jackson.non-osgi.version>
     <dom4j.version>2.1.4</dom4j.version>
     <jaxen.version>1.1.6</jaxen.version>
     <xstream.version>1.4.21</xstream.version>


### PR DESCRIPTION
## Summary

Bumps the jackson family `2.18.9 -> 2.18.10` in the root parent POM, clearing two advisories flagged on `pdia-master@11.1.0.0-390`.

| id | severity | summary | fixed by |
|---|---|---|---|
| **CVE-2026-68497** (Xray `XRAY-1059206`) | High, CVSS 7.5 | Duration / XMLGregorianCalendar unbounded number parse DoS | [GHSA-q4xh-88c3-wmh7](https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-q4xh-88c3-wmh7), upstream [#6127](https://github.com/FasterXML/jackson-databind/issues/6127) |
| **XRAY-1059208** (dispatched as `XRAY-9105451`, no CVE id) | Medium | `java.nio.file.Path` deserialization missing scheme allowlist for `FileSystemProvider` resolution | [GHSA-wjgm-6hv5-3cvf](https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-wjgm-6hv5-3cvf), upstream [#6129](https://github.com/FasterXML/jackson-databind/issues/6129) |

Jira: **PPP-7161** (CVE-2026-68497) and **PPP-7159** (XRAY-1059208) — one change clears both.

## Why 2.18.10 and not 2.22.2

The dashboard recommended 2.22.2. **2.18.10 is the correct minimal target**: it is the lowest version Xray reports with zero issues, and it stays on the 2.18.x line already deployed, so this is a one-patch step instead of a four-minor jump.

| version | Xray issues |
|---|---|
| 2.18.9 (deployed) | 2 — both of the above |
| **2.18.10** | **0** |
| 2.19.1 / 2.19.4 / 2.20.2 | 8 |
| 2.21.6 / 2.22.2 | 0 |

Counter-intuitively the 2.19/2.20 lines are *worse* than 2.18.10: both fixes were backported to 2.18.x, and 2.19/2.20 additionally still carry CVE-2026-54512/54513/54514/54515, CVE-2026-59888 and CVE-2026-77310. Confirmed against the CNA rather than trusting Xray's empty list — the upstream `jackson-databind-2.18.9...jackson-databind-2.18.10` compare contains both fixes verbatim. PPP-7161's own *Fix Versions* field independently lists 2.18.10 / 2.21.6 / 2.22.2.

## Why all three properties

`fasterxml-jackson.version`, `fasterxml-jackson-databind.version` and `fasterxml-jackson.non-osgi.version` were all on 2.18.9 and together govern 11 managed jackson artifacts. jackson is a co-released family, so they move in lockstep to avoid cross-module binary skew; every one of the 11 has a published 2.18.10 (verified individually in the proxy).

`org.codehaus.jackson:*:1.9.13` and `org.hitachivantara:jackson-dataformat-yaml:2.14.1` are deliberately untouched — different coordinates, not part of this finding.

## Binary compatibility — proven from the jars, not from the version number

- **Entry-hash diff of the two jars: 0 entries added, 0 removed**, 19 changed. Five are version carriers (`MANIFEST.MF`, `pom.properties`, `pom.xml`, `PackageVersion`, `module-info`). The 14 substantive classes map 1:1 onto the advisories and release commits — `CoreXMLDeserializers$Std` (#6127), `NioPathDeserializer` (#6129), `StdKeyDeserializer*` (#6166), `DefaultBaseTypeLimitingValidator` (#6155), `InetAddressValidator` (#6116), `TypeFactory` (#6099), `StdDeserializer`.
- **Full public-signature diff** (789 classes, 9,055 signatures via `javap -public`): **0 public signatures removed.** Four added, all additive — `NioPathDeserializer(Collection<String>)`, `DEFAULT_ALLOWED_SCHEMES`, `TYPE_BIG_DECIMAL`, `TYPE_BIG_INTEGER`.

## Verification

**1. The vulnerabilities are actually fixed** — each advisory asserted separately against the real jars, so neither guard is vacuous:

| guard | 2.18.9 (baseline) | 2.18.10 |
|---|---|---|
| `Duration` with a 100,000-digit seconds field | **ACCEPTED** — parsed | **REJECTED** — `StreamConstraintsException: Date/time value length (100003) exceeds the maximum allowed (1000, from StreamReadConstraints.getMaxNumberLength())` |
| `Path` from a non-`file` scheme (`jrt:/java.base/...`) | **ACCEPTED** — resolved to `/modules/java.base/java/lang/Object.class` | **REJECTED** — `InvalidFormatException: ... scheme 'jrt' not allowed for Path deserialization` |

**2. The vulnerable version is gone from the tree.** `pentaho/semantic-model-editor` resolved against this parent, identical command both runs:

```
BEFORE  12 com.fasterxml.jackson.core nodes -- all 2.18.9,  zero 2.18.10
AFTER   12 com.fasterxml.jackson.core nodes -- all 2.18.10, zero 2.18.9
```

Transitive requests for 2.17.2 and 2.18.0 are overridden by the managed version, so no path escapes. `mvn help:effective-pom` on this repo confirms all 11 managed artifacts move together.

## Blast radius

Contained — jackson is an internal serialization library here; no service API, wire protocol, query language or persisted format changes. The only externally observable changes are the hardening itself, and two are worth a reviewer's eye:

- `java.nio.file.Path` deserialization is now restricted to an allowed-scheme list — code that legitimately deserializes a `Path` from a non-`file` URI scheme would now be rejected (the new `NioPathDeserializer(Collection<String>)` constructor is the escape hatch).
- `java.lang.Comparable` is now treated as an unsafe polymorphic base type — affects default typing that declares `Comparable` as the base.

Neither is reachable from a parent-POM change alone; both would surface in consumer builds.

## Not fixed here (not first-party, no fix point)

The same group flagged three other jackson-databind versions in `pdia-master`. Neither is fixable from this repo, and both are recorded on the tracking issues:

- **2.19.0 / 2.19.1** — inside `com.pentaho:enterprise-local-license-server` (`flexnetls.jar`, `flexnetlsconfig.jar`, `flexnetlsadmin.jar`), Revenera vendor fat jars with no first-party declaration.
- **2.22.1** — shaded inside `org.apache.parquet:parquet-jackson:1.18.0` (pulled by `pentaho-big-data-ee-plugin`), flagged via the copy's embedded `META-INF` pom. 1.18.0 is the newest published `parquet-jackson`, so there is no fixed release to bump to.

## No companion PR needed

`pentaho-karaf-assembly` / `pentaho-karaf-ee-assembly` reference `${fasterxml-jackson.version}` / `${fasterxml-jackson-databind.version}` in both their `bundleReplacement` entries and `startup.properties` boot bundles, so those surfaces self-maintain from this bump. An org-wide search found the only literal `2.18.9` in `pentaho`/`webdetails` is this file.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-390", "items": [{"cve": "CVE-2026-68497", "coordinate": "com.fasterxml.jackson.core:jackson-databind"}, {"cve": "XRAY-9105451", "coordinate": "com.fasterxml.jackson.core:jackson-databind"}, {"cve": "XRAY-1059206", "coordinate": "com.fasterxml.jackson.core:jackson-databind"}, {"cve": "XRAY-1059208", "coordinate": "com.fasterxml.jackson.core:jackson-databind"}]} -->
