### PR TITLE
fix[mondrian]: restore Docker-backed integration tests BACKLOG-50612

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
     <pentaho.private.release.repo />
     <pentaho.private.snapshot.repo />
 
-    <pentaho.docker.pull.host>repo.orl.eng.hitachivantara.com/pnt-docker/</pentaho.docker.pull.host>
+    <pentaho.docker.pull.host>repo.eng.pentaho.com/pnt-docker</pentaho.docker.pull.host>
     <!-- No default docker push repository, it must be defined at build-time -->
     <pentaho.docker.push.host>${pentaho.docker.public.push.host}</pentaho.docker.push.host>
 


### PR DESCRIPTION
## Summary

Backports the Docker pull-registry correction required by Mondrian's embedded MySQL integration-test container.

The old `repo.orl.eng.hitachivantara.com/pnt-docker/` host fails TLS validation; the corrected `repo.eng.pentaho.com/pnt-docker` host resolves the MySQL image.

## Original Pull Request

https://github.com/pentaho/maven-parent-poms/pull/965

## Validation

- `docker manifest inspect repo.eng.pentaho.com/pnt-docker/mysql:8.0.27` succeeded.
- `mvn --batch-mode -N -DskipTests install` succeeded for `pentaho-parent-pom:11.0.0.0-SNAPSHOT`.

## Ticket

BACKLOG-50612