### PR TITLE
ci(dependabot): manage Tomcat dependencies [BACKLOG-50660]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -548,6 +548,44 @@
         <version>${jetty.version}</version>
       </dependency>
 
+      <!-- Tomcat -->
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-annotations-api</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-catalina</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-coyote</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-el-api</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-jasper-el</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-jdbc</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-jsp-api</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <!-- Tomcat -->
+
       <!-- Netty -->
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
## Summary
- add Apache Tomcat dependencies to root dependency management
- manage all entries with the existing ${tomcat.version} property
- allow Dependabot to update the shared Tomcat version property

## Managed dependencies
- tomcat-annotations-api
- tomcat-catalina
- tomcat-coyote
- tomcat-el-api
- tomcat-jasper-el
- tomcat-jdbc
- tomcat-jsp-api
