### PR TITLE
[PPP-7203][PPP-7204][PPP-7205][PPP-7206] bump jline 3.30.15 -> 3.30.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <log4j-slf4j2.version>2.25.5</log4j-slf4j2.version>
     <commons-logging.version>1.3.5</commons-logging.version>
     <postgresql.version>42.7.11</postgresql.version>
-    <jline.version>3.30.15</jline.version>
+    <jline.version>3.30.17</jline.version>
 
     <jsch.version>0.2.26</jsch.version>
     <jsendnsca.version>3.0.0</jsendnsca.version>


### PR DESCRIPTION
Bumps `<jline.version>` **3.30.15 -> 3.30.17** in `pentaho-parent-pom`, which manages `org.jline:jline` for the whole platform.

Tracking: **PPP-7203**, **PPP-7204**, **PPP-7205**, **PPP-7206**. CodeMedic run against `pdia-master@11.1.0.0-402`.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-402", "items": [{"cve": "XRAY-1072970", "coordinate": "org.jline:jline-native"}, {"cve": "XRAY-1072971", "coordinate": "org.jline:jline-remote-ssh"}, {"cve": "XRAY-1072973", "coordinate": "org.jline:jline-remote-telnet"}, {"cve": "XRAY-1072974", "coordinate": "org.jline:jline-remote-ssh"}]} -->

## The findings

Four JFrog-private advisories on jline **3.30.15**, all shipped in `pdia-master@11.1.0.0-402`:

| id | Jira | coordinate | sev | summary |
|---|---|---|---|---|
| XRAY-1072970 | PPP-7203 | `jline-native` | High (CVSS 7.0) | Native stack buffer overflow in public `INPUT_RECORD.memmove` JNI method (Windows) |
| XRAY-1072971 | PPP-7204 | `jline-remote-ssh` | Medium | Authenticated SSH shell channel resource leak via null / non-numeric PTY dimensions |
| XRAY-1072973 | PPP-7205 | `jline-remote-telnet` | High (CVSS 7.5) | TCP socket file descriptor leak when maximum connections reached |
| XRAY-1072974 | PPP-7206 | `jline-remote-ssh` | Medium | Authenticated SSH DoS via unbounded window-change terminal geometry |

`dependencyGraph/build` reports **115 jline nodes in the build, all 3.30.15**. These modules reach the product inside the aggregate `org.jline:jline` uber jar, on the `pentaho-big-data-ee-plugin` shim-driver classpath and in the Karaf `system/` directory of the server assemblies.

## Why 3.30.17 and not 4.4.3

The Jira tickets and Xray both name **4.4.3** as the fix version. That is a 3.x -> 4.x **major** bump (jline 4.x restructures its modules), and it is not the minimal fix. Laddering the deployed line shows the fix was backported:

| version | `reader` | `builtins` | `native` | `remote-ssh` | `remote-telnet` |
|---|---|---|---|---|---|
| **3.30.15 (deployed)** | clean | clean | **1072970** | **1072971 + 1072974** | **1072973** |
| 3.30.16 | clean | clean | flagged | flagged | flagged |
| **3.30.17 (this PR)** | clean | clean | **clean** | **clean** | **clean** |
| 4.3.1 | clean | clean | flagged | flagged | flagged |
| 4.4.3 | clean | clean | clean | clean | clean |

Note 4.3.1 -- a major jump -- is strictly **more** vulnerable than 3.30.17. 3.30.17 is one patch step on the line already deployed.

## Upstream evidence (not taken on the scanner's word)

`jline/jline3` commit **`6d00cbc7`** -- *"fix: address remaining security vulnerabilities reported by AFINE/CERT.PL (#2235) (#2238)"* -- is in the `jline-3.30.16...jline-3.30.17` range. Its message maps 1:1 onto the four findings:

```
- ConnectionManager: close socket when max connections reached (FD leak)      -> XRAY-1072973
- ShellFactoryImpl: validate and clamp SSH terminal dimensions (DoS)          -> XRAY-1072974
- ShellFactoryImpl: handle null/non-numeric PTY dimensions, destroy on failure-> XRAY-1072971
- kernel32.c: add bounds check to INPUT_RECORD.memmove (stack buffer overflow)-> XRAY-1072970
- Kernel32.java: reduce memmove visibility to package-private
```

## Compatibility, proven from the JARs

Entry-hash diff of both shipped variants:

| jar | entries | added | removed |
|---|---|---|---|
| `jline-3.30.15.jar` -> `3.30.17.jar` | 623 -> 623 | **0** | **0** |
| `jline-3.30.15-jdk8.jar` -> `3.30.17-jdk8.jar` | 602 -> 602 | **0** | **0** |

Full public-signature diff (`javap -public` across all **522** classes) -- exactly **one** public API line disappears:

```
public static native void memmove(org.jline.nativ.Kernel32$INPUT_RECORD, long, long);
```

That removal **is** the fix for XRAY-1072970: the unbounded public JNI entry point is narrowed to package-private. Its only legitimate caller is jline's own Windows terminal code in the same package, and an org-wide code search for `import org.jline` across `pentaho`/`webdetails` returns **0 first-party hits** -- no first-party code binds to jline at all. No other public member is removed.

## Fix landed in the bits (bytecode, with negative control)

| class | 3.30.15 | 3.30.17 | meaning |
|---|---|---|---|
| `Kernel32$INPUT_RECORD` | `memmove` public | **absent from public API** | XRAY-1072970 fixed |
| `telnet/ConnectionManager.makeConnection(Socket)` | 93 instrs, 1 `Socket.close` ref | **107 instrs, 2 `Socket.close` refs** | XRAY-1072973 FD leak closed |
| `ssh/ShellFactoryImpl` | 117 disasm lines | **146 lines, newly references `Integer.parseInt`** | XRAY-1072971/1072974 dimension parsing + clamping |

## Dependency resolution before/after

Resolved through this parent POM:

```
BEFORE:  \- org.jline:jline:jar:3.30.15:compile
AFTER:   \- org.jline:jline:jar:3.30.17:compile
```

`3.30.15` is absent from the re-resolved tree.

## Scope and limitations

- Single-property change at the highest declaring point; no leaf overrides added. `pentaho-hadoop-shims` inherits `${jline.version}` from here and needs no edit.
- **No new tests.** No first-party code imports `org.jline`, so there is no first-party code path to exercise -- adding a test here would be a vacuous assertion. The security claim rests on the version-absence, public-API and bytecode evidence above, stated plainly rather than papered over.
- **This PR does not fix the Karaf-side copy on its own.** The `jline-3.30.15-jdk8.jar` under `pentaho-solutions/system/karaf/system/` comes from the custom Karaf distribution. Companion PR: **pentaho/karaf#PPP-7203-jline-3.30.17** (branch `hitachi_custom_4.4.6`). That one requires a custom Karaf release plus a `<pentaho.custom.karaf.version>` bump here -- release engineering, tracked in the CodeMedic escalation issue.

Not auto-merged; please review.