### PR TITLE
[DEVO-14362] Repoint Maven repository URLs to repo.pentaho.com (11.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,10 +363,10 @@
     <javascript-doc_copy-resources-phase>pre-site</javascript-doc_copy-resources-phase>
 
     <!-- Node and npm root repositoryies -->
-    <nodeDownloadRoot>https://repo.orl.eng.hitachivantara.com/artifactory/nodejs-dist/</nodeDownloadRoot>
-    <npmDownloadRoot>https://repo.orl.eng.hitachivantara.com/artifactory/npm-release/npm/-/</npmDownloadRoot>
+    <nodeDownloadRoot>https://repo.pentaho.com/artifactory/nodejs-dist/</nodeDownloadRoot>
+    <npmDownloadRoot>https://repo.pentaho.com/artifactory/npm-release/npm/-/</npmDownloadRoot>
 
-    <pentaho.resolve.repo>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn</pentaho.resolve.repo>
+    <pentaho.resolve.repo>https://repo.pentaho.com/artifactory/pnt-mvn</pentaho.resolve.repo>
     <!-- No default repository URL deployments, these must be defined at build-time -->
     <pentaho.public.release.repo />
     <pentaho.public.snapshot.repo />


### PR DESCRIPTION
Repoints Maven repository hostnames on the `11.0` service pack line.

- `repo.orl.eng.hitachivantara.com` -> `repo.pentaho.com`
- Host-only substitution; the `/artifactory/<path>/` segment, scheme and trailing slash are preserved
- Repository `<id>`/`<name>` unchanged; no version, formatting or ordering changes
- Files changed: 1, occurrences replaced: 3
- `mvn -B validate` passes

Base is `11.0`, not the default branch. Ticket: DEVO-14362.