### PR TITLE
DEVO-14362: point Maven repository URLs at repo.pentaho.com (10.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,17 +321,17 @@
     <javascript-doc_copy-resources-phase>pre-site</javascript-doc_copy-resources-phase>
 
     <!-- Node and npm root repositoryies -->
-    <nodeDownloadRoot>https://repo.orl.eng.hitachivantara.com/artifactory/nodejs-dist/</nodeDownloadRoot>
-    <npmDownloadRoot>https://repo.orl.eng.hitachivantara.com/artifactory/npm-release/npm/-/</npmDownloadRoot>
+    <nodeDownloadRoot>https://repo.pentaho.com/artifactory/nodejs-dist/</nodeDownloadRoot>
+    <npmDownloadRoot>https://repo.pentaho.com/artifactory/npm-release/npm/-/</npmDownloadRoot>
 
-    <pentaho.resolve.repo>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn</pentaho.resolve.repo>
+    <pentaho.resolve.repo>https://repo.pentaho.com/artifactory/pnt-mvn</pentaho.resolve.repo>
     <!-- No default repository URL deployments, these must be defined at build-time -->
     <pentaho.public.release.repo />
     <pentaho.public.snapshot.repo />
     <pentaho.private.release.repo />
     <pentaho.private.snapshot.repo />
 
-    <pentaho.docker.pull.host>repo.orl.eng.hitachivantara.com/pnt-docker/</pentaho.docker.pull.host>
+    <pentaho.docker.pull.host>repo.pentaho.com/pnt-docker/</pentaho.docker.pull.host>
     <!-- No default docker push repository, it must be defined at build-time -->
     <pentaho.docker.push.host>${pentaho.docker.public.push.host}</pentaho.docker.push.host>
 


### PR DESCRIPTION
Backports the DEVO-14362 hostname change to the `10.2` service pack line.

`repo.orl.eng.hitachivantara.com` -> `repo.pentaho.com`, hostname only. Every `/artifactory/<path>/` segment,
scheme and trailing slash is preserved verbatim; no ids, names, versions or
formatting were touched.

- Files changed: 1
- Occurrences replaced: 4
- `mvn validate` passes
- `grep` for the old hostname over all `pom.xml` returns no hits

Base is `10.2`, not the default branch. Ticket: DEVO-14362