### PR TITLE
[PPP-7212..PPP-7227] Upgrade Netty to 4.1.138.Final (21 security findings, pdia-master@11.1.0.0-402)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
     <amqp.version>5.22.0</amqp.version>
     <mina-core.version>2.2.8</mina-core.version>
     <saxon-he.version>12.7</saxon-he.version>
-    <netty.version>4.1.137.Final</netty.version>
+    <netty.version>4.1.138.Final</netty.version>
     <pentaho-shaded-netty.version>4.1.137.Final-pentaho-1</pentaho-shaded-netty.version>
     <netty-tcnative.version>2.0.81.Final</netty-tcnative.version>
     <xmlresolver.version>6.0.17</xmlresolver.version>


### PR DESCRIPTION
## What

Bumps `netty.version` from **4.1.137.Final** to **4.1.138.Final**.

Opened by CodeMedic for **21 security findings** on build `pdia-master@11.1.0.0-402`.

## Why here

`netty.version` governs **all 31 managed `io.netty` artifacts** in this POM's `dependencyManagement`, on both the CE and EE chains. It is the highest definition point for the Netty family across the platform, so this one-line change is the whole fix -- no leaf overrides were added anywhere.

The vulnerable jars reach the product as `netty-codec-*.jar` in `pentaho-server-{ce,ee}`, `pentaho-server-manual-{ce,ee}`, `pdi-ce`, `pdi-ee-client` and all four `pentaho-big-data-ee-plugin-11.1.0.0-402-{apachevanilla,cdp,dataproc,emr}.zip` distributions -- 63 entry points in total, every one of them resolved through this property.

## Why this version, and why not the recommended ones

The findings recommend `5.0.0.Alpha2` or `4.2.7.Final`. **Both are wrong, and one is dangerous.**

| candidate | netty-codec-http | netty-codec-http2 | verdict |
|---|---|---|---|
| 4.1.137.Final (deployed) | 8 | 5 | vulnerable |
| **4.1.138.Final (this PR)** | **1** | **0** | next patch on the deployed line |
| 4.2.7.Final (recommended) | 24 | 12 | **strictly worse than today** |
| 5.0.0.Alpha2 (recommended) | 0 | 0 | abandoned 2015 alpha -- 0 because nothing scans it |

`5.0.0.Alpha2` is listed as `<release>` in `maven-metadata.xml` only because it sorts highest; it is not a successor to 4.1.x, and adopting it would have been a serious regression. `4.2.7.Final` would have *increased* the finding count.

`4.1.138.Final` (released 2026-09-09) is same-line and binary compatible. The Netty family is BOM-aligned, so the whole set moves together, which this property already guarantees.

## Verification

**Effective POM, before -> after** (`mvn -N help:effective-pom`):

```
before: 31 managed io.netty artifacts @ 4.1.137.Final
after:  31 managed io.netty artifacts @ 4.1.138.Final
        (netty-tcnative-boringssl-static stays at 2.0.81.Final -- separate property, not affected)
```

**Resolution against the internal proxy** -- all 28 non-classifier artifacts fetched successfully at 4.1.138.Final (`dependency:get`, 28/28 OK), plus the classifier-bearing natives: `netty-transport-native-epoll:linux-x86_64`, `netty-transport-native-kqueue:osx-x86_64` and `netty-resolver-dns-native-macos:osx-x86_64` all return HTTP 200. No member of the family is missing at the new version.

This POM is a packaging-`pom` parent with no sources, so there is nothing here to unit-test; the behavioural regression guards for this upgrade live in the companion PR, pentaho/third-party-libraries#11, which reproduces two of the advisories on 4.1.137.Final and shows them fixed on 4.1.138.Final.

## What is deliberately NOT changed

`pentaho-shaded-netty.version` stays at `4.1.137.Final-pentaho-1`. That artifact is built from `pentaho/third-party-libraries`, and `4.1.138.Final-pentaho-1` **is not published yet** -- moving the pin now would break every consumer build. Sequence:

1. Merge pentaho/third-party-libraries#11 and release `pentaho-shaded-netty:4.1.138.Final-pentaho-1`.
2. Then bump `pentaho-shaded-netty.version` here to match.

Until step 2 lands, the shaded copy of Netty inside the big-data plugin zips is still on 4.1.137.Final. **Both changes are required for the findings to clear.**

## Known gap -- one finding is NOT fixed by this PR

**XRAY-1074997** (HTTP request smuggling via control characters in the chunk-size line, PPP-7224) has **no fix in any published Netty release**. The advisory was created 2026-09-10, one day after 4.1.138.Final shipped. `HttpObjectDecoder#checkChunkExtensions` is byte-identical at 4.1.137, 4.1.138 and 4.2.18, so no available upgrade clears it -- including the 4.2 line, which the scanner reports as clean for it. Tracked separately rather than chased with a speculative bump that would have closed the finding while still shipping the vulnerable code.

## Note on the commit subject

The bracketed `[PPP-nnnn]` prefix is a standing requirement for this automation and takes precedence over a repo-local commit convention. If a commit-message check fails on it, that is expected and is for a human to decide -- the subject was not restructured and the branch was not force-pushed to hide it.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-402", "items": [{"cve": "XRAY-1074968", "coordinate": "io.netty:netty-codec-http"}, {"cve": "XRAY-1074970", "coordinate": "io.netty:netty-codec-http"}, {"cve": "XRAY-1074980", "coordinate": "io.netty:netty-codec-http"}, {"cve": "XRAY-1074981", "coordinate": "io.netty:netty-codec-http"}, {"cve": "XRAY-1074984", "coordinate": "io.netty:netty-codec-http"}, {"cve": "XRAY-1074993", "coordinate": "io.netty:netty-codec-http"}, {"cve": "XRAY-1074996", "coordinate": "io.netty:netty-codec-http"}, {"cve": "XRAY-1074971", "coordinate": "io.netty:netty-codec-http2"}, {"cve": "XRAY-1074975", "coordinate": "io.netty:netty-codec-http2"}, {"cve": "XRAY-1074976", "coordinate": "io.netty:netty-codec-http2"}, {"cve": "XRAY-1074977", "coordinate": "io.netty:netty-codec-http2"}, {"cve": "XRAY-1074999", "coordinate": "io.netty:netty-codec-http2"}, {"cve": "XRAY-1074974", "coordinate": "io.netty:netty-codec-smtp"}, {"cve": "XRAY-1074992", "coordinate": "io.netty:netty-codec-smtp"}, {"cve": "XRAY-1074979", "coordinate": "io.netty:netty-codec-stomp"}, {"cve": "XRAY-1074983", "coordinate": "io.netty:netty-codec-stomp"}, {"cve": "XRAY-1074985", "coordinate": "io.netty:netty-codec-haproxy"}, {"cve": "XRAY-1074987", "coordinate": "io.netty:netty-handler-ssl-ocsp"}, {"cve": "XRAY-1074989", "coordinate": "io.netty:netty-codec-mqtt"}, {"cve": "XRAY-1074995", "coordinate": "io.netty:netty-codec-redis"}, {"cve": "XRAY-1075000", "coordinate": "io.netty:netty-codec-memcache"}]} -->